### PR TITLE
refactor: create lib and seperate modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,11 @@ tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 rstest = "0.19.0"
+
+[lib]
+name = "pcu_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pcu"
+path = "src/main.rs"

--- a/src/change_frag.rs
+++ b/src/change_frag.rs
@@ -1,5 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
+use crate::PrTitle;
+
 #[derive(Debug, PartialEq)]
 enum Heading {
     Added,
@@ -50,12 +52,12 @@ impl From<&str> for Heading {
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct ChangeRecord {
+pub struct ChangeFrag {
     heading: Heading,
     description: String,
 }
 
-impl ChangeRecord {
+impl ChangeFrag {
     fn new(heading: &str, description: &str) -> Self {
         // <1>
         let heading = Heading::from(heading);
@@ -66,7 +68,7 @@ impl ChangeRecord {
     }
 }
 
-impl From<&PrTitle> for ChangeRecord {
+impl From<&PrTitle> for ChangeFrag {
     fn from(pr_title: &PrTitle) -> Self {
         // <2>
         let mut heading_str = pr_title
@@ -99,110 +101,12 @@ impl From<&PrTitle> for ChangeRecord {
     }
 }
 
-#[derive(Debug)]
-pub struct PrTitle {
-    title: String,
-    commit_type: Option<String>,
-    commit_scope: Option<String>,
-    commit_breaking: bool,
-}
-
-impl PrTitle {
-    pub fn parse(title: &str) -> Self {
-        let re = regex::Regex::new(
-            r"^(?P<type>[a-z]+)(?:\((?P<scope>[a-z]+)\))?(?P<breaking>!)?: (?P<description>.*)$",
-        )
-        .unwrap();
-
-        if let Some(captures) = re.captures(title) {
-            let commit_type = captures.name("type").map(|m| m.as_str().to_string());
-            let commit_scope = captures.name("scope").map(|m| m.as_str().to_string());
-            let commit_breaking = captures.name("breaking").is_some();
-            let title = captures
-                .name("description")
-                .map(|m| m.as_str().to_string())
-                .unwrap();
-
-            Self {
-                title,
-                commit_type,
-                commit_scope,
-                commit_breaking,
-            }
-        } else {
-            Self {
-                title: title.to_string(),
-                commit_type: None,
-                commit_scope: None,
-                commit_breaking: false,
-            }
-        }
-    }
-}
-
 //test module
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
     use super::*;
-
-    #[test]
-    fn test_pr_title_parse() {
-        let pr_title = PrTitle::parse("feat: add new feature");
-        assert_eq!(pr_title.title, "add new feature");
-        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
-        assert_eq!(pr_title.commit_scope, None);
-        assert!(!pr_title.commit_breaking);
-
-        let pr_title = PrTitle::parse("feat(core): add new feature");
-        assert_eq!(pr_title.title, "add new feature");
-        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
-        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
-        assert!(!pr_title.commit_breaking);
-
-        let pr_title = PrTitle::parse("feat(core)!: add new feature");
-        assert_eq!(pr_title.title, "add new feature");
-        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
-        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
-        assert!(pr_title.commit_breaking);
-    }
-
-    #[test]
-    fn test_pr_title_parse_with_breaking_scope() {
-        let pr_title = PrTitle::parse("feat(core)!: add new feature");
-        assert_eq!(pr_title.title, "add new feature");
-        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
-        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
-        assert!(pr_title.commit_breaking);
-    }
-
-    #[test]
-    fn test_pr_title_parse_with_security_scope() {
-        let pr_title = PrTitle::parse("fix(security): fix security vulnerability");
-        assert_eq!(pr_title.title, "fix security vulnerability");
-        assert_eq!(pr_title.commit_type, Some("fix".to_string()));
-        assert_eq!(pr_title.commit_scope, Some("security".to_string()));
-        assert!(!pr_title.commit_breaking);
-    }
-
-    #[test]
-    fn test_pr_title_parse_with_deprecate_scope() {
-        let pr_title = PrTitle::parse("chore(deprecate): deprecate old feature");
-        assert_eq!(pr_title.title, "deprecate old feature");
-        assert_eq!(pr_title.commit_type, Some("chore".to_string()));
-        assert_eq!(pr_title.commit_scope, Some("deprecate".to_string()));
-        assert!(!pr_title.commit_breaking);
-    }
-
-    #[test]
-    fn test_pr_title_parse_without_scope() {
-        let pr_title = PrTitle::parse("docs: update documentation");
-        assert_eq!(pr_title.title, "update documentation");
-        assert_eq!(pr_title.commit_type, Some("docs".to_string()));
-        assert_eq!(pr_title.commit_scope, None);
-        assert!(!pr_title.commit_breaking);
-    }
 
     #[test]
     fn test_heading_display() {
@@ -273,7 +177,7 @@ mod tests {
         #[case] expected_heading: Heading,
         #[case] expected_description: &str,
     ) {
-        let change_record = ChangeRecord::new(heading, description);
+        let change_record = ChangeFrag::new(heading, description);
         assert_eq!(expected_heading, change_record.heading);
         assert_eq!(expected_description, change_record.description);
     }
@@ -321,7 +225,7 @@ mod tests {
         #[case] expected_description: &str,
     ) {
         let pr_title = PrTitle::parse(title);
-        let change_record = ChangeRecord::from(&pr_title);
+        let change_record = ChangeFrag::from(&pr_title);
         assert_eq!(expected_heading, change_record.heading);
         assert_eq!(expected_description, change_record.description);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+mod change_frag;
+mod pr_title;
+
+pub use change_frag::ChangeFrag;
+pub use pr_title::PrTitle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use std::env;
 
-use crate::log_update::{ChangeRecord, PrTitle};
-
-mod log_update;
+use pcu_lib::{ChangeFrag, PrTitle};
 
 #[tokio::main]
 async fn main() {
@@ -35,7 +33,7 @@ async fn changelog_update() -> Result<(), octocrab::Error> {
         if let Some(title) = pr.title.as_ref() {
             let pr_title = PrTitle::parse(title);
             println!("PR: {:#?}", pr_title);
-            let change_frag = ChangeRecord::from(&pr_title);
+            let change_frag = ChangeFrag::from(&pr_title);
             println!("Change record: {:#?}", change_frag);
         }
     });

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -1,0 +1,103 @@
+#[derive(Debug)]
+pub struct PrTitle {
+    pub title: String,
+    pub commit_type: Option<String>,
+    pub commit_scope: Option<String>,
+    pub commit_breaking: bool,
+}
+
+impl PrTitle {
+    pub fn parse(title: &str) -> Self {
+        let re = regex::Regex::new(
+            r"^(?P<type>[a-z]+)(?:\((?P<scope>[a-z]+)\))?(?P<breaking>!)?: (?P<description>.*)$",
+        )
+        .unwrap();
+
+        if let Some(captures) = re.captures(title) {
+            let commit_type = captures.name("type").map(|m| m.as_str().to_string());
+            let commit_scope = captures.name("scope").map(|m| m.as_str().to_string());
+            let commit_breaking = captures.name("breaking").is_some();
+            let title = captures
+                .name("description")
+                .map(|m| m.as_str().to_string())
+                .unwrap();
+
+            Self {
+                title,
+                commit_type,
+                commit_scope,
+                commit_breaking,
+            }
+        } else {
+            Self {
+                title: title.to_string(),
+                commit_type: None,
+                commit_scope: None,
+                commit_breaking: false,
+            }
+        }
+    }
+}
+
+//test module
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pr_title_parse() {
+        let pr_title = PrTitle::parse("feat: add new feature");
+        assert_eq!(pr_title.title, "add new feature");
+        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
+        assert_eq!(pr_title.commit_scope, None);
+        assert!(!pr_title.commit_breaking);
+
+        let pr_title = PrTitle::parse("feat(core): add new feature");
+        assert_eq!(pr_title.title, "add new feature");
+        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
+        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
+        assert!(!pr_title.commit_breaking);
+
+        let pr_title = PrTitle::parse("feat(core)!: add new feature");
+        assert_eq!(pr_title.title, "add new feature");
+        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
+        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
+        assert!(pr_title.commit_breaking);
+    }
+
+    #[test]
+    fn test_pr_title_parse_with_breaking_scope() {
+        let pr_title = PrTitle::parse("feat(core)!: add new feature");
+        assert_eq!(pr_title.title, "add new feature");
+        assert_eq!(pr_title.commit_type, Some("feat".to_string()));
+        assert_eq!(pr_title.commit_scope, Some("core".to_string()));
+        assert!(pr_title.commit_breaking);
+    }
+
+    #[test]
+    fn test_pr_title_parse_with_security_scope() {
+        let pr_title = PrTitle::parse("fix(security): fix security vulnerability");
+        assert_eq!(pr_title.title, "fix security vulnerability");
+        assert_eq!(pr_title.commit_type, Some("fix".to_string()));
+        assert_eq!(pr_title.commit_scope, Some("security".to_string()));
+        assert!(!pr_title.commit_breaking);
+    }
+
+    #[test]
+    fn test_pr_title_parse_with_deprecate_scope() {
+        let pr_title = PrTitle::parse("chore(deprecate): deprecate old feature");
+        assert_eq!(pr_title.title, "deprecate old feature");
+        assert_eq!(pr_title.commit_type, Some("chore".to_string()));
+        assert_eq!(pr_title.commit_scope, Some("deprecate".to_string()));
+        assert!(!pr_title.commit_breaking);
+    }
+
+    #[test]
+    fn test_pr_title_parse_without_scope() {
+        let pr_title = PrTitle::parse("docs: update documentation");
+        assert_eq!(pr_title.title, "update documentation");
+        assert_eq!(pr_title.commit_type, Some("docs".to_string()));
+        assert_eq!(pr_title.commit_scope, None);
+        assert!(!pr_title.commit_breaking);
+    }
+}


### PR DESCRIPTION
* fix(change_frag.rs): rename log_update.rs to change_frag.rs and update imports and references accordingly
* feat(pr_title.rs): add PrTitle struct and parse function for parsing PR titles
* feat(main.rs): update imports and references to use pcu_lib instead of log_update
* feat(lib.rs): add module declarations for change_frag and pr_title and re-export them from the library
* test(pr_title.rs): add unit tests for parsing PR titles