### PR TITLE
refactor: string output from repo status

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -209,13 +209,13 @@ impl Client {
         self.changelog = changelog.into();
     }
 
-    pub fn repo_status(&self) -> Result<(), Error> {
+    pub fn repo_status(&self) -> Result<String, Error> {
         let repo = Repository::open(".")?;
         // let remote = repo.find_remote(&self.branch)?;
         let statuses = repo.statuses(None)?;
 
-        print_long(&statuses);
-        Ok(())
+        let report = print_long(&statuses);
+        Ok(report)
 
         // // if statuses.is_empty() {
         // //     Ok(format!("On branch {}\n", self.branch))
@@ -233,11 +233,13 @@ impl Client {
 
 // This function print out an output similar to git's status command in long
 // form, including the command-line hints.
-fn print_long(statuses: &git2::Statuses) {
+fn print_long(statuses: &git2::Statuses) -> String {
     let mut header = false;
     let mut rm_in_workdir = false;
     let mut changes_in_index = false;
     let mut changed_in_workdir = false;
+
+    let mut output = String::new();
 
     // Print index changes
     for entry in statuses
@@ -256,11 +258,12 @@ fn print_long(statuses: &git2::Statuses) {
             _ => continue,
         };
         if !header {
-            println!(
-                "\
-# Changes to be committed:
-#   (use \"git reset HEAD <file>...\" to unstage)
-#"
+            output = format!(
+                "{}\n\
+                # Changes to be committed:
+                #   (use \"git reset HEAD <file>...\" to unstage)
+                #",
+                output
             );
             header = true;
         }
@@ -269,17 +272,28 @@ fn print_long(statuses: &git2::Statuses) {
         let new_path = entry.head_to_index().unwrap().new_file().path();
         match (old_path, new_path) {
             (Some(old), Some(new)) if old != new => {
-                println!("#\t{}  {} -> {}", istatus, old.display(), new.display());
+                output = format!(
+                    "{}\n#\t{}  {} -> {}",
+                    output,
+                    istatus,
+                    old.display(),
+                    new.display()
+                );
             }
             (old, new) => {
-                println!("#\t{}  {}", istatus, old.or(new).unwrap().display());
+                output = format!(
+                    "{}\n#\t{}  {}",
+                    output,
+                    istatus,
+                    old.or(new).unwrap().display()
+                );
             }
         }
     }
 
     if header {
         changes_in_index = true;
-        println!("#");
+        output = format!("{}\n", output);
     }
     header = false;
 
@@ -301,13 +315,15 @@ fn print_long(statuses: &git2::Statuses) {
         };
 
         if !header {
-            println!(
-                "\
-# Changes not staged for commit:
-#   (use \"git add{} <file>...\" to update what will be committed)
-#   (use \"git checkout -- <file>...\" to discard changes in working directory)
-#\
+            output = format!(
+                "{}\n
+                \
+                # Changes not staged for commit:
+                #   (use \"git add{} <file>...\" to update what will be committed)
+                #   (use \"git checkout -- <file>...\" to discard changes in working directory)
+                #\
                 ",
+                output,
                 if rm_in_workdir { "/rm" } else { "" }
             );
             header = true;
@@ -317,10 +333,21 @@ fn print_long(statuses: &git2::Statuses) {
         let new_path = entry.index_to_workdir().unwrap().new_file().path();
         match (old_path, new_path) {
             (Some(old), Some(new)) if old != new => {
-                println!("#\t{}  {} -> {}", istatus, old.display(), new.display());
+                output = format!(
+                    "{}\n#\t{}  {} -> {}",
+                    output,
+                    istatus,
+                    old.display(),
+                    new.display()
+                );
             }
             (old, new) => {
-                println!("#\t{}  {}", istatus, old.or(new).unwrap().display());
+                output = format!(
+                    "{}\n#\t{}  {}",
+                    output,
+                    istatus,
+                    old.or(new).unwrap().display()
+                );
             }
         }
     }
@@ -337,11 +364,12 @@ fn print_long(statuses: &git2::Statuses) {
         .filter(|e| e.status() == git2::Status::WT_NEW)
     {
         if !header {
-            println!(
-                "\
-# Untracked files
-#   (use \"git add <file>...\" to include in what will be committed)
-#"
+            output = format!(
+                "{}\n
+                # Untracked files
+                #   (use \"git add <file>...\" to include in what will be committed)
+                #",
+                output
             );
             header = true;
         }
@@ -356,22 +384,27 @@ fn print_long(statuses: &git2::Statuses) {
         .filter(|e| e.status() == git2::Status::IGNORED)
     {
         if !header {
-            println!(
-                "\
-# Ignored files
-#   (use \"git add -f <file>...\" to include in what will be committed)
-#"
+            output = format!(
+                "{}\n
+                # Ignored files
+                #   (use \"git add -f <file>...\" to include in what will be committed)
+                #",
+                output
             );
             header = true;
         }
         let file = entry.index_to_workdir().unwrap().old_file().path().unwrap();
-        println!("#\t{}", file.display());
+        output = format!("{}\n#\t{}", output, file.display());
     }
 
     if !changes_in_index && changed_in_workdir {
-        println!(
-            "no changes added to commit (use \"git add\" and/or \
-             \"git commit -a\")"
+        output = format!(
+            "{}\n
+            no changes added to commit (use \"git add\" and/or \
+            \"git commit -a\")",
+            output
         );
     }
+
+    output
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ async fn changelog_update(mut client: Client) -> Result<()> {
 
     print_changelog(client.changelog());
 
-    client.repo_status()?;
+    let report = client.repo_status()?;
+    println!("Repo state:\n{report}");
     // let statuses = client.repo_status()?;
 
     // println!("Repo state:");


### PR DESCRIPTION
* fix(client.rs): change return type of `repo_status` method from `Result<(), Error>` to `Result<String, Error>`
* feat(client.rs): add `print_long` function to print out git status in long form and return the output as a string
* feat(main.rs): print repository state after updating changelog