### PR TITLE
fix: missing untracked file names

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -374,7 +374,7 @@ fn print_long(statuses: &git2::Statuses) -> String {
             header = true;
         }
         let file = entry.index_to_workdir().unwrap().old_file().path().unwrap();
-        println!("#\t{}", file.display());
+        output = format!("{}\n#\t{}", output, file.display());
     }
     header = false;
 


### PR DESCRIPTION
* chore(client.rs): refactor print_long function to append file paths to output variable instead of printing directly