### PR TITLE
chore: investigate remote failure

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -139,9 +139,18 @@ impl Client {
     }
 
     pub fn push_changelog(&self) -> Result<(), git2::Error> {
-        let mut remote = self
+        let mut remote = match self
             .git_repo
-            .find_remote(format!("origin/{}", self.branch).as_str())?;
+            .find_remote(format!("origin/{}", self.branch).as_str())
+        {
+            Ok(remote) => remote,
+            Err(_) => {
+                println!("Remote not found");
+                self.git_repo
+                    .remote_anonymous(format!("origin/{}", self.branch).as_str())?
+            }
+        };
+        println!("Pushing changes to {}", remote.name().unwrap());
         // remote.connect(git2::Direction::Push)?;
         remote.push(&[""], None)?;
 


### PR DESCRIPTION
* fix(client.rs): handle case when remote is not found and use remote_anonymous instead