### PR TITLE
feat: Return early if the changlog has been updated already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Return early if the changlog has been updated already(pr [#93](https://github.com/jerus-org/pcu/pull/93))
+
+
 ### Changed
 
 - ci-tidy up and clarify removal of original ssh key(pr [#92](https://github.com/jerus-org/pcu/pull/92))

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,15 +110,15 @@ impl Client {
         Ok(())
     }
 
-    pub fn update_changelog(&mut self) -> Result<(), Error> {
+    pub fn update_changelog(&mut self) -> Result<Option<(ChangeKind, String)>, Error> {
         if self.changelog_update.is_none() {
             return Err(Error::NoChangeLogFileFound);
         }
 
         if let Some(update) = &mut self.changelog_update {
-            update.update_changelog(&self.changelog);
+            return Ok(update.update_changelog(&self.changelog));
         }
-        Ok(())
+        Ok(None)
     }
 
     pub fn commit_changelog(&self) -> Result<String, Error> {

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -156,7 +156,7 @@ impl PrTitle {
         }
     }
 
-    pub fn update_changelog(&mut self, log_file: &OsStr) {
+    pub fn update_changelog(&mut self, log_file: &OsStr) -> Option<(ChangeKind, String)> {
         let log_file = log_file.to_str().unwrap();
         self.calculate_section_and_entry();
 
@@ -167,7 +167,7 @@ impl PrTitle {
             println!("file contents:\n---\n{}\n---\n\n", file_contents);
             if file_contents.contains(&self.entry) {
                 println!("The changelog already contains the entry!");
-                return;
+                return None;
             } else {
                 println!("The changelog does not contain the entry!");
             }
@@ -209,8 +209,9 @@ impl PrTitle {
                 unreleased.changed(self.entry());
             }
         }
-
         change_log.save_to_file(log_file).unwrap();
+
+        Some((self.section(), self.entry()))
     }
 }
 


### PR DESCRIPTION
* feat(client.rs): update the `update_changelog` function to return an `Option<(ChangeKind, String)>` instead of `Result<(), Error>`
* feat(main.rs): modify `changelog_update` function to handle the updated return type of `update_changelog` function in `Client` struct. Print the proposed addition to the change log if an update is required. Print "No update required" if no update is needed.
* feat(pr_title.rs): modify `update_changelog` function in `PrTitle` struct to return an `Option<(ChangeKind, String)>` instead of `()` to indicate whether an update was made or not. Return `None` if the changelog already contains the entry. Return `Some((section, entry))` if an update was made.