### PR TITLE
refactor: align var and restore simple commit without signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
             git config --global user.email "$BOT_USER_EMAIL"
             git config --global user.name "$BOT_USER_NAME"
             git config --global gpg.program gpg
-            git config --global user.signingkey "$BOT_SIGN_KEY!"
+            git config --global user.signingkey "$BOT_SIGN_KEY"
             git config --global commit.gpgsign true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-return to using none in commit_signed(pr [#100](https://github.com/jerus-org/pcu/pull/100))
 
 
+### Fixed
+
+- align with data in the env var(pr [#101](https://github.com/jerus-org/pcu/pull/101))
+
+
 ### Security
 
 - Security: adopt new ci bot signature(pr [#95](https://github.com/jerus-org/pcu/pull/95))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return early if the changelog has been updated already(pr [#93](https://github.com/jerus-org/pcu/pull/93))
 
+
 ### Changed
 
 - ci-tidy up and clarify removal of original ssh key(pr [#92](https://github.com/jerus-org/pcu/pull/92))
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-update branch message to remove personal pronoun(pr [#98](https://github.com/jerus-org/pcu/pull/98))
 - refactor-remove commented out code(pr [#99](https://github.com/jerus-org/pcu/pull/99))
 - chore-return to using none in commit_signed(pr [#100](https://github.com/jerus-org/pcu/pull/100))
+- refactor-align var and restore simple commit without signing(pr [#101](https://github.com/jerus-org/pcu/pull/101))
+
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return early if the changelog has been updated already(pr [#93](https://github.com/jerus-org/pcu/pull/93))
 
-
 ### Changed
 
 - ci-tidy up and clarify removal of original ssh key(pr [#92](https://github.com/jerus-org/pcu/pull/92))
@@ -21,12 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-update branch message to remove personal pronoun(pr [#98](https://github.com/jerus-org/pcu/pull/98))
 - refactor-remove commented out code(pr [#99](https://github.com/jerus-org/pcu/pull/99))
 - chore-return to using none in commit_signed(pr [#100](https://github.com/jerus-org/pcu/pull/100))
-
-
-### Fixed
-
-- align with data in the env var(pr [#101](https://github.com/jerus-org/pcu/pull/101))
-
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return early if the changelog has been updated already(pr [#93](https://github.com/jerus-org/pcu/pull/93))
 
+
 ### Changed
 
 - ci-tidy up and clarify removal of original ssh key(pr [#92](https://github.com/jerus-org/pcu/pull/92))
@@ -20,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-update branch message to remove personal pronoun(pr [#98](https://github.com/jerus-org/pcu/pull/98))
 - refactor-remove commented out code(pr [#99](https://github.com/jerus-org/pcu/pull/99))
 - chore-return to using none in commit_signed(pr [#100](https://github.com/jerus-org/pcu/pull/100))
+
+
+### Fixed
+
+- align with data in the env var(pr [#101](https://github.com/jerus-org/pcu/pull/101))
+
 
 ### Security
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ use crate::Error;
 use crate::PrTitle;
 
 const CHANGELOG_FILENAME: &str = "CHANGELOG.md";
-const SIGNATURE_KEY: &str = "BOT_SIGN_KEY";
+// const SIGNATURE_KEY: &str = "BOT_SIGN_KEY";
 const DEFAULT_CHANGELOG_COMMIT_MSG: &str = "chore: update changelog";
 
 pub struct Client {
@@ -131,34 +131,35 @@ impl Client {
         let head = self.git_repo.head()?;
         let parent = self.git_repo.find_commit(head.target().unwrap())?;
         let sig = self.git_repo.signature()?;
-
-        let email = sig.email().unwrap();
-        let email = email[..4].to_string();
-        println!("Email: {email}");
-
-        let name = sig.name().unwrap();
-        let name = name[..4].to_string();
-        println!("Name: {name}");
-
         let msg = DEFAULT_CHANGELOG_COMMIT_MSG;
-        let commit_buffer = self.git_repo.commit_create_buffer(
+
+        let commit_id = self.git_repo.commit(
+            Some("HEAD"),
             &sig,
             &sig,
             msg,
             &self.git_repo.find_tree(tree_id)?,
             &[&parent],
         )?;
-        let commit_str = std::str::from_utf8(&commit_buffer).unwrap();
 
-        let signature = env::var(SIGNATURE_KEY)?;
+        // let commit_buffer = self.git_repo.commit_create_buffer(
+        //     &sig,
+        //     &sig,
+        //     msg,
+        //     &self.git_repo.find_tree(tree_id)?,
+        //     &[&parent],
+        // )?;
+        // let commit_str = std::str::from_utf8(&commit_buffer).unwrap();
 
-        // let signature = self.git_repo.config()?.get_string(SIGNATURE_KEY)?;
-        let short_sign = signature[12..].to_string();
-        println!("Signature short: {short_sign}");
-        let commit_id = self.git_repo.commit_signed(commit_str, &signature, None)?;
+        // let signature = env::var(SIGNATURE_KEY)?;
 
-        // manually advance to the new commit id
-        self.git_repo.head()?.set_target(commit_id, msg)?;
+        // // let signature = self.git_repo.config()?.get_string(SIGNATURE_KEY)?;
+        // let short_sign = signature[12..].to_string();
+        // println!("Signature short: {short_sign}");
+        // let commit_id = self.git_repo.commit_signed(commit_str, &signature, None)?;
+
+        // // manually advance to the new commit id
+        // self.git_repo.head()?.set_target(commit_id, msg)?;
 
         Ok(commit_id.to_string())
     }


### PR DESCRIPTION
* fix(config.yml): remove exclamation mark from BOT_SIGN_KEY variable in git config command
* chore(client.rs): comment out unused SIGNATURE_KEY constant
* refactor(client.rs): remove unused code and commented out code
* fix(client.rs): fix commit creation by using git_repo.commit instead of git_repo.commit_create_buffer
* refactor(client.rs): remove unused variables and print statements
* refactor(client.rs): remove unused code for setting target commit