### PR TITLE
feat: allow log environment variables to override command line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Update changelog
           command: |
             pcu -h
-            pcu -vv
+            pcu -vvv
   make-release:
     executor: rust-env
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - logger and logging (pr [#102](https://github.com/jerus-org/pcu/pull/102))
 - sign the commit using gpg(pr [#107](https://github.com/jerus-org/pcu/pull/107))
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
-- add constants for log environment variables(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-remove blanks(pr [#114](https://github.com/jerus-org/pcu/pull/114))
 - chore-display messages using logging(pr [#115](https://github.com/jerus-org/pcu/pull/115))
 - refactor-replace println with logging(pr [#116](https://github.com/jerus-org/pcu/pull/116))
+- refactor-rename changelog_update function to run_update(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore-remove blanks(pr [#114](https://github.com/jerus-org/pcu/pull/114))
 - chore-display messages using logging(pr [#115](https://github.com/jerus-org/pcu/pull/115))
 - refactor-replace println with logging(pr [#116](https://github.com/jerus-org/pcu/pull/116))
-- refactor-rename changelog_update function to run_update(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - logger and logging (pr [#102](https://github.com/jerus-org/pcu/pull/102))
 - sign the commit using gpg(pr [#107](https://github.com/jerus-org/pcu/pull/107))
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
+- allow log environment variables to override command line(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - logger and logging (pr [#102](https://github.com/jerus-org/pcu/pull/102))
 - sign the commit using gpg(pr [#107](https://github.com/jerus-org/pcu/pull/107))
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
+- add constants for log environment variables(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 
 ### Changed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
-use std::fs;
+use std::{env, fs};
 
 use clap::Parser;
-use env_logger::WriteStyle;
+use env_logger::Env;
 use keep_a_changelog::ChangeKind;
 use pcu_lib::{Client, Error};
 
 use eyre::Result;
+
+const LOG_ENV_VAR: &str = "PCU_LOG";
+const LOG_STYLE_ENV_VAR: &str = "PCU_LOG_STYLE";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -107,13 +110,17 @@ fn print_changelog(changelog_path: &str) {
 
 fn get_logging(level: log::LevelFilter) -> env_logger::Builder {
     println!("Making builder with Log level: {level}");
-    let mut builder = env_logger::Builder::new();
 
-    builder.filter(None, level);
+    let env = Env::new()
+        .filter_or(LOG_ENV_VAR, level.to_string())
+        .write_style_or(LOG_STYLE_ENV_VAR, "auto");
+
+    let mut builder = env_logger::Builder::from_env(env);
+
+    if env::var(LOG_ENV_VAR).is_err() {
+        builder.filter_module("pcu;pcu_lib", level);
+    }
     builder.format_timestamp_secs();
-    builder.write_style(WriteStyle::Auto);
-
-    builder.format_timestamp_secs().format_module_path(false);
 
     builder
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         client.branch()
     );
 
-    match changelog_update(client).await {
+    match run_update(client).await {
         Ok(_) => log::info!("Changelog updated!"),
         Err(e) => log::error!("Error updating changelog: {e}"),
     };
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn changelog_update(mut client: Client) -> Result<()> {
+async fn run_update(mut client: Client) -> Result<()> {
     log::debug!(
         "PR ID: {} - Owner: {} - Repo: {}",
         client.pr_number(),


### PR DESCRIPTION
Restrict modules reported when logging to based on command line to those logs generated by this crate. 

* chore(main.rs): refactor logging configuration in get_logging function
* fix(main.rs): fix println statement in get_logging function
* feat(main.rs): add constants for log environment variables