### PR TITLE
feat: add Sign enum and sign field to Cli struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sign the commit using gpg(pr [#107](https://github.com/jerus-org/pcu/pull/107))
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
 - allow log environment variables to override command line(pr [#118](https://github.com/jerus-org/pcu/pull/118))
-- add Sign enum and sign field to Cli struct(pr [#121](https://github.com/jerus-org/pcu/pull/121))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sign the commit using gpg(pr [#107](https://github.com/jerus-org/pcu/pull/107))
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
 - allow log environment variables to override command line(pr [#118](https://github.com/jerus-org/pcu/pull/118))
+- add Sign enum and sign field to Cli struct(pr [#121](https://github.com/jerus-org/pcu/pull/121))
 
 ### Changed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,5 +131,6 @@ fn get_logging(level: log::LevelFilter) -> env_logger::Builder {
     }
     builder.format_timestamp_secs();
 
+    println!("Builder: {builder:#?}");
     builder
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, fs};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use env_logger::Env;
 use keep_a_changelog::ChangeKind;
 use pcu_lib::{Client, Error};
@@ -10,11 +10,20 @@ use eyre::Result;
 const LOG_ENV_VAR: &str = "PCU_LOG";
 const LOG_STYLE_ENV_VAR: &str = "PCU_LOG_STYLE";
 
+#[derive(ValueEnum, Debug, Default, Clone)]
+enum Sign {
+    None,
+    #[default]
+    Gpg,
+}
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(flatten)]
     logging: clap_verbosity_flag::Verbosity,
+    #[clap(short, long)]
+    sign: Sign,
 }
 
 #[tokio::main]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Build out the CII to provide a  sign option  to determine how  pcu should sign the commit with the change log update. Create an enum for the signing options including initially `none` (not signed) and `gpg` . Gpg is the default option. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While it is desibable to have the commits signed to authenticate the changes on the repository this may not be an options that can be configured by every user (or that every user desires) and therefore an unsigned option should be allowed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Initial setup

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Change logs have been updated
