### PR TITLE
feat: add match for sign types in run_update function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Update changelog
           command: |
             pcu -h
-            pcu -vvv
+            pcu -vvv --sign gpg
   make-release:
     executor: rust-env
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
 - allow log environment variables to override command line(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 - add Sign enum and sign field to Cli struct(pr [#121](https://github.com/jerus-org/pcu/pull/121))
+- add match for sign types in run_update function(pr [#122](https://github.com/jerus-org/pcu/pull/122))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add CLI flag to set verbosity of logs(pr [#117](https://github.com/jerus-org/pcu/pull/117))
 - allow log environment variables to override command line(pr [#118](https://github.com/jerus-org/pcu/pull/118))
 - add Sign enum and sign field to Cli struct(pr [#121](https://github.com/jerus-org/pcu/pull/121))
-- add match for sign types in run_update function(pr [#122](https://github.com/jerus-org/pcu/pull/122))
 
 ### Changed
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,7 +156,7 @@ impl Client {
     }
 
     #[allow(dead_code)]
-    pub fn commit_changelog_signed(&self) -> Result<String, Error> {
+    pub fn commit_changelog_gpg(&self) -> Result<String, Error> {
         let mut index = self.git_repo.index()?;
         index.add_path(Path::new(self.changelog()))?;
         index.write()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
     #[clap(flatten)]
     logging: clap_verbosity_flag::Verbosity,
     #[clap(short, long)]
-    sign: Sign,
+    sign: Option<Sign>,
 }
 
 #[tokio::main]
@@ -49,7 +49,13 @@ async fn main() -> Result<()> {
         client.branch()
     );
 
-    match run_update(client, args.sign).await {
+    let sign = if let Some(sign) = args.sign {
+        sign
+    } else {
+        Sign::default()
+    };
+
+    match run_update(client, sign).await {
         Ok(_) => log::info!("Changelog updated!"),
         Err(e) => log::error!("Error updating changelog: {e}"),
     };
@@ -129,7 +135,7 @@ fn get_logging(level: log::LevelFilter) -> env_logger::Builder {
     println!("Making builder with Log level: {level}");
 
     let env = Env::new()
-        .filter_or(LOG_ENV_VAR, level.to_string())
+        .filter_or(LOG_ENV_VAR, "level.to_string()")
         .write_style_or(LOG_STYLE_ENV_VAR, "auto");
 
     let mut builder = env_logger::Builder::from_env(env);

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
         client.branch()
     );
 
-    match run_update(client).await {
+    match run_update(client, args.sign).await {
         Ok(_) => log::info!("Changelog updated!"),
         Err(e) => log::error!("Error updating changelog: {e}"),
     };
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_update(mut client: Client) -> Result<()> {
+async fn run_update(mut client: Client, sign: Sign) -> Result<()> {
     log::debug!(
         "PR ID: {} - Owner: {} - Repo: {}",
         client.pr_number(),
@@ -96,7 +96,15 @@ async fn run_update(mut client: Client) -> Result<()> {
     log::debug!("Before commit:Repo state: {report}");
     log::debug!("before commit:Branch status: {}", client.branch_status()?);
 
-    client.commit_changelog_signed()?;
+    match sign {
+        Sign::Gpg => {
+            client.commit_changelog_gpg()?;
+        }
+        Sign::None => {
+            client.commit_changelog()?;
+        }
+    }
+
     log::debug!("After commit: Repo state: {}", client.repo_status()?);
     log::debug!("After commit: Branch status: {}", client.branch_status()?);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Operartionalise the option that was provided earlier by matching the choice made and calling the relevant client method.

* refactor(client.rs): rename commit_changelog_signed to commit_changelog_gpg
* feat(main.rs): add sign parameter to run_update function
* feat(main.rs): add match case for GPG and None sign types in run_update 
* feat(main.rs): make sign argument optional in Cli struct
* fix(main.rs): set default value for sign if not provided
* fix(main.rs): correct the logging level assignment in get_logging function
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While it is desibable to have the commits signed to authenticate the changes on the repository this may not be an options that can be configured by every user (or that every user desires) and therefore an unsigned option should be allowed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Initial setup

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Change logs have been updated
