### PR TITLE
chore: remove  cargo release  comment replacements

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -12,6 +12,4 @@ pre-release-replacements = [
     { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
     { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
     { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
-    { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly = 1 },
-    { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/jerus-org/pcu/compare/{{tag_name}}...HEAD", exactly = 1 },
 ]


### PR DESCRIPTION
* chore: comment out pre-release-replacements for next-header and next-url in release.toml
