### PR TITLE
chore: user cargo home bin version of pcu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,7 @@ jobs:
       - run:
           name: Update changelog
           command: |
-            echo $CARGO_HOME
-            pcu -vv
+            $CARGO_HOME/bin/pcu -vv
   make-release:
     executor: rust-env
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore-test for value of CARGO_HOME(pr [#152](https://github.com/jerus-org/pcu/pull/152))
+- chore-user cargo home bin version of pcu(pr [#153](https://github.com/jerus-org/pcu/pull/153))
 
 ## [0.1.2] - 2024-06-12
 


### PR DESCRIPTION
* chore(circleci): update changelog command to use absolute path for pcu binary

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
