### PR TITLE
refactor: remove unwrap from string conversion of OsStr value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- refactor-remove unwrap from string conversion of OsStr value(pr [#159](https://github.com/jerus-org/pcu/pull/159))
+
 ## [0.1.3] - 2024-06-15
 
 ### Changed
@@ -104,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Security: adopt new ci bot signature(pr [#95](https://github.com/jerus-org/pcu/pull/95))
 
-[0.1.3]: https://github.com/jerus-org/pcu/compare/0.1.2...v0.1.3
+[Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.3...HEAD
+[0.1.3]: https://github.com/jerus-org/pcu/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/jerus-org/pcu/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/jerus-org/pcu/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/jerus-org/pcu/releases/tag/0.1.0

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,7 +121,7 @@ impl Client {
     }
 
     pub fn create_entry(&mut self) -> Result<(), Error> {
-        let mut pr_title = PrTitle::parse(&self.title);
+        let mut pr_title = PrTitle::parse(&self.title)?;
         pr_title.pr_id = Some(self.pr_number);
         pr_title.pr_url = Some(Url::from_str(&self.pull_request)?);
         pr_title.calculate_section_and_entry();

--- a/src/client.rs
+++ b/src/client.rs
@@ -137,7 +137,8 @@ impl Client {
         }
 
         if let Some(update) = &mut self.changelog_update {
-            return Ok(update.update_changelog(&self.changelog));
+            #[allow(clippy::needless_question_mark)]
+            return Ok(update.update_changelog(&self.changelog)?);
         }
         Ok(None)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use regex::Error as RegexError;
 use std::{env, ffi::OsString, num::ParseIntError};
 use thiserror::Error;
 
@@ -25,6 +26,10 @@ pub enum Error {
     DefaultChangeLogNotSet,
     #[error("Invalid path for changelog file {0:?}")]
     InvalidPath(OsString),
+    #[error("Regex string is not valid.")]
+    InvalidRegex,
+    #[error("Keep a changelog says: {0}")]
+    KeepAChangelog(String),
     #[error("On default branch")]
     OnDefaultBranch,
     #[error("Unknown format for pull request: {0}")]
@@ -47,4 +52,6 @@ pub enum Error {
     Utf8(#[from] std::str::Utf8Error),
     #[error("config error says: {0:?}")]
     Config(#[from] config::ConfigError),
+    #[error("regex error says: {0:?}")]
+    Regex(#[from] RegexError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{env, num::ParseIntError};
+use std::{env, ffi::OsString, num::ParseIntError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -23,6 +23,8 @@ pub enum Error {
     EnvVarPullRequestNotFound,
     #[error("Default change log file name not set")]
     DefaultChangeLogNotSet,
+    #[error("Invalid path for changelog file {0:?}")]
+    InvalidPath(OsString),
     #[error("On default branch")]
     OnDefaultBranch,
     #[error("Unknown format for pull request: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,7 @@ async fn main() -> Result<()> {
         client.branch()
     );
 
-    let sign = if let Some(sign) = args.sign {
-        sign
-    } else {
-        Sign::default()
-    };
+    let sign = args.sign.unwrap_or_default();
 
     match run_update(client, sign).await {
         Ok(_) => log::info!("Changelog updated!"),


### PR DESCRIPTION
* fix(client.rs): handle potential error when parsing PR title in create_entry method
* fix(error.rs): add handling for RegexError in Error enum
* fix(pr_title.rs): change parse method to return Result and handle potential errors in parsing and updating changelog
* test(pr_title.rs): add tests for parsing PR titles with different scopes and types
* test(pr_title.rs): add tests for parsing PR titles with breaking changes and different scopes
* fix(client.rs): add clippy lint to handle unnecessary question mark operator
* fix(error.rs): import OsString from ffi module to handle InvalidPath error
* fix(main.rs): refactor sign variable initialization using unwrap_or_default method
* fix(pr_title.rs): handle Result type for update_changelog method and return error for invalid path


<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
