### PR TITLE
feat: add early_exit flag for signaling an early exit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - run:
           name: Update changelog
           command: |
-            $CARGO_HOME/bin/pcu -vv
+            $CARGO_HOME/bin/pcu -vvv
   make-release:
     executor: rust-env
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add support for generating repository URL from PR URL(pr [#167])
 - add support for parsing changelog with repository URL in ChangelogParseOptions(pr [#168])
 - print message when changelog updated(pr [#176])
+- add early_exit flag for signaling an early exit(pr [#177])
 
 ### Changed
 
@@ -169,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#174]: https://github.com/jerus-org/pcu/pull/174
 [#175]: https://github.com/jerus-org/pcu/pull/175
 [#176]: https://github.com/jerus-org/pcu/pull/176
+[#177]: https://github.com/jerus-org/pcu/pull/177
 [Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.8...HEAD
 [0.1.8]: https://github.com/jerus-org/pcu/compare/0.1.7...0.1.8
 [0.1.7]: https://github.com/jerus-org/pcu/compare/0.1.6...0.1.7

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,7 +161,13 @@ impl Client {
     }
 
     pub fn update_changelog(&mut self) -> Result<Option<(ChangeKind, String)>, Error> {
-        if self.changelog_update.is_none() {
+        log::debug!(
+            "Updating changelog: {:?} with entry {:?}",
+            self.changelog,
+            self.changelog_update
+        );
+
+        if self.changelog.is_empty() {
             return Err(Error::NoChangeLogFileFound);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,8 @@ async fn run_update(mut client: Client, sign: Sign) -> Result<ClState> {
 
     client.create_entry()?;
 
+    log::debug!("Proposed entry: {:?}", client.entry());
+
     if log::log_enabled!(log::Level::Info) {
         if let Some((section, entry)) = client.update_changelog()? {
             let section = match section {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,7 @@ use color_eyre::Result;
 
 const LOG_ENV_VAR: &str = "RUST_LOG";
 const LOG_STYLE_ENV_VAR: &str = "RUST_LOG_STYLE";
-const UPDATED: &str = "updates";
-const NOT_UPDATED: &str = "none";
+const SIGNAL_HALT: &str = "halt";
 
 #[derive(ValueEnum, Debug, Default, Clone)]
 enum Sign {
@@ -26,7 +25,16 @@ struct Cli {
     #[clap(flatten)]
     logging: clap_verbosity_flag::Verbosity,
     #[clap(short, long)]
+    /// Require the user to sign the update commit with their GPG key
     sign: Option<Sign>,
+    /// Signal an early exit as the changelog is already updated
+    #[clap(short, long, default_value_t = false)]
+    early_exit: bool,
+}
+
+enum ClState {
+    Updated,
+    UnChanged,
 }
 
 #[tokio::main]
@@ -42,6 +50,9 @@ async fn main() -> Result<()> {
         Err(e) => match e {
             Error::EnvVarPullRequestNotFound => {
                 log::info!("On the main branch, so nothing more to do!");
+                if args.early_exit {
+                    println!("{SIGNAL_HALT}");
+                }
                 return Ok(());
             }
             _ => return Err(e.into()),
@@ -56,9 +67,13 @@ async fn main() -> Result<()> {
     let sign = args.sign.unwrap_or_default();
 
     match run_update(client, sign).await {
-        Ok(result) => {
+        Ok(state) => {
             log::info!("Changelog updated!");
-            println!("{result}");
+            if let ClState::Updated = state {
+                if args.early_exit {
+                    println!("{SIGNAL_HALT}");
+                }
+            }
         }
         Err(e) => {
             log::error!("Error updating changelog: {e}");
@@ -69,7 +84,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_update(mut client: Client, sign: Sign) -> Result<String> {
+async fn run_update(mut client: Client, sign: Sign) -> Result<ClState> {
     log::debug!(
         "PR ID: {} - Owner: {} - Repo: {}",
         client.pr_number(),
@@ -96,7 +111,7 @@ async fn run_update(mut client: Client, sign: Sign) -> Result<String> {
             log::info!("Amendment: In section `{section}`, adding `{entry}`");
         } else {
             log::info!("No update required");
-            return Ok(NOT_UPDATED.to_string());
+            return Ok(ClState::UnChanged);
         };
     }
 
@@ -125,7 +140,7 @@ async fn run_update(mut client: Client, sign: Sign) -> Result<String> {
     client.push_changelog()?;
     log::debug!("After push: Branch status: {}", client.branch_status()?);
 
-    Ok(UPDATED.to_string())
+    Ok(ClState::Updated)
 }
 
 fn print_changelog(changelog_path: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,8 @@ async fn run_update(mut client: Client, sign: Sign) -> Result<ClState> {
             log::info!("No update required");
             return Ok(ClState::UnChanged);
         };
+    } else if client.update_changelog()?.is_none() {
+        return Ok(ClState::UnChanged);
     }
 
     log::debug!("Changelog file name: {}", client.changelog());

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     let mut builder = get_logging(args.logging.log_level_filter());
     builder.init();
 
-    log::debug!("Settings for github client: {settings:#?}");
+    log::trace!("Settings for github client: {settings:?}");
     let client = match Client::new_with(settings).await {
         Ok(client) => client,
         Err(e) => match e {


### PR DESCRIPTION
Replaces the previous "updated" and "not updated" messages.
* feat(main.rs): add early_exit flag for signaling an early exit
* refactor(main.rs): replace string constants UPDATED and NOT_UPDATED with ClState enum
* fix(main.rs): update run_update function to return ClState instead of String
* feat(main.rs): add SIGNAL_HALT constant for early exit signal

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
