### PR TITLE
chore: restore crates.io version of keep-a-changelog and update toolkit version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     description: "If true, the success pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@0.19.0
+  toolkit: jerus-org/circleci-toolkit@0.20.0
 
 executors:
   rust-env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,8 +978,9 @@ dependencies = [
 
 [[package]]
 name = "keep-a-changelog"
-version = "0.1.3"
-source = "git+https://github.com/jerusdp/keep-a-changelog-rs.git?branch=feat-add-link#4f5966ca5d03868947941605187de3d524c909e9"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154a24ccde8f0778a086abaabaf2acd1a177a15be5a4076e74491d0d2687e896"
 dependencies = [
  "chrono",
  "derive-getters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ include = ["**/*.rs", "Cargo.toml", "README.md", "LICENSE"]
 categories = ["development-tools::build-utils", "command-line-utilities"]
 
 [dependencies]
-# keep-a-changelog = "0.1.3"
-keep-a-changelog = { git = "https://github.com/jerusdp/keep-a-changelog-rs.git", branch = "feat-add-link" }
+keep-a-changelog = "0.1.3"
+# keep-a-changelog = { git = "https://github.com/jerusdp/keep-a-changelog-rs.git", branch = "feat-add-link" }
 octocrab = "0.38.0"
 regex = "1.10.5"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
* chore(.circleci/config.yml): upgrade toolkit version from 0.19.0 to 0.20.0
* fix(Cargo.toml): revert keep-a-changelog dependency to version 0.1.3 from git branch feat-add-link

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
