### PR TITLE
fix: use local octocrab instance add bot-check context to make_release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ workflows:
       - make_release:
           context:
             - release
+            - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           pcu_verbosity: "-vvvv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- use local octocrab instance add bot-check context to make_release workflow(pr [#223])
+
 ## [0.1.16] - 2024-07-24
 
 ### Changed
@@ -314,7 +320,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#220]: https://github.com/jerus-org/pcu/pull/220
 [#221]: https://github.com/jerus-org/pcu/pull/221
 [#222]: https://github.com/jerus-org/pcu/pull/222
-[0.1.16]: https://github.com/jerus-org/pcu/compare/0.1.15...v0.1.16
+[#223]: https://github.com/jerus-org/pcu/pull/223
+[Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.16...HEAD
+[0.1.16]: https://github.com/jerus-org/pcu/compare/0.1.15...0.1.16
 [0.1.15]: https://github.com/jerus-org/pcu/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/jerus-org/pcu/compare/0.1.13...0.1.14
 [0.1.13]: https://github.com/jerus-org/pcu/compare/0.1.12...0.1.13

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -477,7 +477,7 @@ impl Client {
         let commit = Client::get_commitish_for_tag(self, &octocrab, version).await?;
         log::trace!("Commit: {:#?}", commit);
 
-        let release_notes = octocrab::instance()
+        let release_notes = octocrab
             .repos(self.owner(), self.repo())
             .releases()
             .generate_release_notes(version)


### PR DESCRIPTION
* feat(.circleci/config.yml): add bot-check context to make_release workflow
* fix(client/mod.rs): use local octocrab instance for generating release notes

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
