### PR TITLE
fix: format version string with 'v' prefix in generate_release_notes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- format version string with 'v' prefix in generate_release_notes method(pr [#224])
+
 ## [0.1.17] - 2024-07-24
 
 ### Fixed
@@ -321,7 +327,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#221]: https://github.com/jerus-org/pcu/pull/221
 [#222]: https://github.com/jerus-org/pcu/pull/222
 [#223]: https://github.com/jerus-org/pcu/pull/223
-[0.1.17]: https://github.com/jerus-org/pcu/compare/0.1.16...v0.1.17
+[#224]: https://github.com/jerus-org/pcu/pull/224
+[Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.17...HEAD
+[0.1.17]: https://github.com/jerus-org/pcu/compare/0.1.16...0.1.17
 [0.1.16]: https://github.com/jerus-org/pcu/compare/0.1.15...0.1.16
 [0.1.15]: https://github.com/jerus-org/pcu/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/jerus-org/pcu/compare/0.1.13...0.1.14

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -480,7 +480,7 @@ impl Client {
         let release_notes = octocrab
             .repos(self.owner(), self.repo())
             .releases()
-            .generate_release_notes(version)
+            .generate_release_notes(format!("v{version}").as_str())
             .send()
             .await?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
