### PR TITLE
fix: modify version_tag reference format in git_repo.find_reference method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - push the version tag to the repo(pr [#234])
 - add optional tag parameter to commit_changelog and commit_changelog_gpg functions(pr [#235])
 - change commit_changelog_gpg method to mutable(pr [#236])
+- modify version_tag reference format in git_repo.find_reference method(pr [#237])
 
 ## [0.1.24] - 2024-07-25
 
@@ -390,6 +391,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#234]: https://github.com/jerus-org/pcu/pull/234
 [#235]: https://github.com/jerus-org/pcu/pull/235
 [#236]: https://github.com/jerus-org/pcu/pull/236
+[#237]: https://github.com/jerus-org/pcu/pull/237
 [Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.24...HEAD
 [0.1.24]: https://github.com/jerus-org/pcu/compare/0.1.23...0.1.24
 [0.1.23]: https://github.com/jerus-org/pcu/compare/0.1.22...0.1.23

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -360,7 +360,7 @@ impl Client {
         let branch_ref = local_branch.into_reference();
         let mut push_refs = vec![branch_ref.name().unwrap()];
         let tag_ref = if let Some(version_tag) = version {
-            let tag_ref = self.git_repo.find_reference(version_tag)?;
+            let tag_ref = self.git_repo.find_reference(&format!("v{version_tag}"))?;
             log::trace!("Found tag: {:?}", tag_ref.name().unwrap());
             tag_ref.name().unwrap().to_string()
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
