### PR TITLE
fix: prepend 'v' to version_tag before tagging commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add optional tag parameter to commit_changelog and commit_changelog_gpg functions(pr [#235])
 - change commit_changelog_gpg method to mutable(pr [#236])
 - modify version_tag reference format in git_repo.find_reference method(pr [#237])
+- prepend 'v' to version_tag before tagging commit(pr [#241])
 
 ## [0.1.24] - 2024-07-25
 
@@ -398,6 +399,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#238]: https://github.com/jerus-org/pcu/pull/238
 [#239]: https://github.com/jerus-org/pcu/pull/239
 [#240]: https://github.com/jerus-org/pcu/pull/240
+[#241]: https://github.com/jerus-org/pcu/pull/241
 [Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.24...HEAD
 [0.1.24]: https://github.com/jerus-org/pcu/compare/0.1.23...0.1.24
 [0.1.23]: https://github.com/jerus-org/pcu/compare/0.1.22...0.1.23

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -235,8 +235,9 @@ impl Client {
 
         if let Some(version_tag) = tag {
             let object = self.git_repo.find_object(commit_id, None)?;
+            let version_tag = format!("v{}", version_tag);
             self.git_repo
-                .tag(version_tag, &object, &sig, version_tag, true)?;
+                .tag(&version_tag, &object, &sig, &version_tag, true)?;
         };
 
         Ok(commit_id.to_string())
@@ -319,8 +320,9 @@ impl Client {
 
         if let Some(version_tag) = tag {
             let object = self.git_repo.find_object(commit_id, None)?;
+            let version_tag = format!("v{}", version_tag);
             self.git_repo
-                .tag(version_tag, &object, &sig, version_tag, true)?;
+                .tag(&version_tag, &object, &sig, &version_tag, true)?;
         };
 
         // manually advance to the new commit id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
