### PR TITLE
feat(client): extract git operations to a separate module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min-rust-version:
     type: string
-    default: "1.74"
+    default: "1.75"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     description: "If true, the success pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@0.24.0
+  toolkit: jerus-org/circleci-toolkit@0.25.0
 
 executors:
   rust-env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- extract git operations to a separate module(pr [#243])
+
 ### Changed
 
 - chore-add logging for tag retrieval in get_commitish_for_tag function(pr [#233])
@@ -405,6 +409,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#240]: https://github.com/jerus-org/pcu/pull/240
 [#241]: https://github.com/jerus-org/pcu/pull/241
 [#242]: https://github.com/jerus-org/pcu/pull/242
+[#243]: https://github.com/jerus-org/pcu/pull/243
 [Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.24...HEAD
 [0.1.24]: https://github.com/jerus-org/pcu/compare/0.1.23...0.1.24
 [0.1.23]: https://github.com/jerus-org/pcu/compare/0.1.22...0.1.23

--- a/src/client/git_ops.rs
+++ b/src/client/git_ops.rs
@@ -1,0 +1,235 @@
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use git2::{BranchType, Cred, Direction, Oid, RemoteCallbacks, Signature};
+use octocrab::Octocrab;
+
+use crate::Error;
+
+use super::Client;
+
+const GIT_USER_SIGNATURE: &str = "user.signingkey";
+
+pub trait GitOps {
+    fn create_tag(&self, tag: &str, commit_id: Oid, sig: &Signature) -> Result<(), Error>;
+    #[allow(async_fn_in_trait)]
+    async fn get_commitish_for_tag(
+        &self,
+        octocrab: &Octocrab,
+        version: &str,
+    ) -> Result<String, Error>;
+    fn push_changelog(&self, version: Option<&str>) -> Result<(), Error>;
+    fn commit_changelog_gpg(&mut self, tag: Option<&str>) -> Result<String, Error>;
+    fn commit_changelog(&self, tag: Option<&str>) -> Result<String, Error>;
+}
+
+impl GitOps for Client {
+    #[allow(dead_code)]
+    fn commit_changelog(&self, tag: Option<&str>) -> Result<String, Error> {
+        let mut index = self.git_repo.index()?;
+        index.add_path(Path::new(self.changelog()))?;
+        index.write()?;
+        let tree_id = index.write_tree()?;
+        let head = self.git_repo.head()?;
+        let parent = self.git_repo.find_commit(head.target().unwrap())?;
+        let sig = self.git_repo.signature()?;
+        let msg: String = self.settings.get("commit_message")?;
+
+        let commit_id = self.git_repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &msg,
+            &self.git_repo.find_tree(tree_id)?,
+            &[&parent],
+        )?;
+
+        if let Some(version_tag) = tag {
+            let version_tag = format!("v{}", version_tag);
+            self.create_tag(&version_tag, commit_id, &sig)?;
+        };
+
+        Ok(commit_id.to_string())
+    }
+
+    #[allow(dead_code)]
+    fn commit_changelog_gpg(&mut self, tag: Option<&str>) -> Result<String, Error> {
+        let mut index = self.git_repo.index()?;
+        index.add_path(Path::new(self.changelog()))?;
+        index.write()?;
+        let tree_id = index.write_tree()?;
+        let head = self.git_repo.head()?;
+        let parent = self.git_repo.find_commit(head.target().unwrap())?;
+        let sig = self.git_repo.signature()?;
+        let msg: String = self.settings.get("commit_message")?;
+
+        let commit_buffer = self.git_repo.commit_create_buffer(
+            &sig,
+            &sig,
+            &msg,
+            &self.git_repo.find_tree(tree_id)?,
+            &[&parent],
+        )?;
+        let commit_str = std::str::from_utf8(&commit_buffer).unwrap();
+
+        let signature = self.git_repo.config()?.get_string(GIT_USER_SIGNATURE)?;
+
+        let short_sign = signature[12..].to_string();
+        log::trace!("Signature short: {short_sign}");
+
+        let gpg_args = vec!["--status-fd", "2", "-bsau", signature.as_str()];
+        log::trace!("gpg args: {:?}", gpg_args);
+
+        let mut cmd = Command::new("gpg");
+        cmd.args(gpg_args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+
+        let mut stdin = child.stdin.take().ok_or(Error::Stdin)?;
+        log::trace!("Secured access to stdin");
+
+        log::trace!("Input for signing:\n-----\n{}\n-----", commit_str);
+
+        stdin.write_all(commit_str.as_bytes())?;
+        log::trace!("writing complete");
+        drop(stdin); // close stdin to not block indefinitely
+        log::trace!("stdin closed");
+
+        let output = child.wait_with_output()?;
+        log::trace!("secured output");
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            log::trace!("stderr: {}", stderr);
+            return Err(Error::Stdout(stderr.to_string()));
+        }
+
+        let stderr = std::str::from_utf8(&output.stderr)?;
+
+        if !stderr.contains("\n[GNUPG:] SIG_CREATED ") {
+            return Err(Error::GpgError(
+                "failed to sign data, program gpg failed, SIG_CREATED not seen in stderr"
+                    .to_string(),
+            ));
+        }
+        log::trace!("Error checking completed without error");
+
+        let commit_signature = std::str::from_utf8(&output.stdout)?;
+
+        log::trace!("secured signed commit:\n{}", commit_signature);
+
+        let commit_id =
+            self.git_repo
+                .commit_signed(commit_str, commit_signature, Some("gpgsig"))?;
+
+        log::trace!("commit id: {}", commit_id);
+
+        if let Some(version_tag) = tag {
+            let version_tag = format!("v{}", version_tag);
+            self.create_tag(&version_tag, commit_id, &sig)?;
+        };
+
+        // manually advance to the new commit id
+        self.git_repo.head()?.set_target(commit_id, &msg)?;
+
+        log::trace!("head updated");
+
+        Ok(commit_id.to_string())
+    }
+
+    fn create_tag(&self, tag: &str, commit_id: Oid, sig: &Signature) -> Result<(), Error> {
+        let object = self.git_repo.find_object(commit_id, None)?;
+        self.git_repo.tag(tag, &object, sig, tag, true)?;
+
+        let mut revwalk = self.git_repo.revwalk()?;
+        let reference = format!("refs/tags/{tag}");
+        revwalk.push_ref(&reference)?;
+        Ok(())
+    }
+
+    fn push_changelog(&self, version: Option<&str>) -> Result<(), Error> {
+        let mut remote = self.git_repo.find_remote("origin")?;
+        log::trace!("Pushing changes to {:?}", remote.name());
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_url, username_from_url, _allowed_types| {
+            Cred::ssh_key_from_agent(username_from_url.unwrap())
+        });
+        let mut connection = remote.connect_auth(Direction::Push, Some(callbacks), None)?;
+        let remote = connection.remote();
+
+        log::trace!("Branch: {:?} or {}", self.branch, self.branch());
+
+        let branch = match self.branch {
+            Some(ref branch) => {
+                log::trace!("*** found a branch: {}", branch);
+                branch
+            }
+            None => {
+                log::trace!("*** no branch found, defaulting to main");
+                "main"
+            }
+        };
+
+        let local_branch = self.git_repo.find_branch(branch, BranchType::Local)?;
+        log::trace!("Found branch: {}", local_branch.name()?.unwrap());
+
+        log::trace!("Got these refs: {:?}", list_tags());
+
+        let branch_ref = local_branch.into_reference();
+        let mut push_refs = vec![branch_ref.name().unwrap()];
+        let tag_ref = if let Some(version_tag) = version {
+            log::trace!("Found version tag: {}", version_tag);
+            format!("/refs/tags/v{version_tag}")
+        } else {
+            String::from("")
+        };
+        if !tag_ref.is_empty() {
+            push_refs.push(&tag_ref);
+        }
+        log::trace!("Push refs: {:?}", push_refs);
+
+        remote.push(&push_refs, None)?;
+
+        Ok(())
+    }
+
+    async fn get_commitish_for_tag(
+        &self,
+        octocrab: &Octocrab,
+        version: &str,
+    ) -> Result<String, Error> {
+        log::trace!("Get commitish for tag: {version}");
+        for tag in octocrab
+            .repos(self.owner(), self.repo())
+            .list_tags()
+            .send()
+            .await?
+        {
+            log::trace!("Tag: {:#?}", tag);
+            if tag.name == format!("v{version}").as_str() {
+                return Ok(tag.commit.sha);
+            }
+        }
+
+        Err(Error::TagNotFound(version.to_string()))
+    }
+}
+
+fn list_tags() -> String {
+    let output = Command::new("ls")
+        .arg("-lR")
+        .arg(".git/refs")
+        .output()
+        .expect("ls of the git refs");
+    let stdout = output.stdout;
+
+    let string = String::from_utf8_lossy(&stdout);
+
+    string.to_string()
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,20 +3,21 @@ use std::{
     env,
     ffi::OsString,
     fs,
-    io::Write,
-    path::{self, Path},
-    process::{Command, Stdio},
+    path::{self},
     str::FromStr,
     sync::Arc,
 };
 
+mod git_ops;
 mod pull_request;
+
+pub use git_ops::GitOps;
 
 use self::pull_request::PullRequest;
 
 use chrono::{Datelike, NaiveDate, Utc};
 use config::Config;
-use git2::{BranchType, Cred, Direction, RemoteCallbacks, Repository};
+use git2::Repository;
 use keep_a_changelog::{
     changelog::ChangelogBuilder, ChangeKind, Changelog, ChangelogParseOptions, Release, Version,
 };
@@ -25,8 +26,6 @@ use url::Url;
 
 use crate::PrTitle;
 use crate::{release_notes_provider::ReleaseNotesProvider, Error};
-
-const GIT_USER_SIGNATURE: &str = "user.signingkey";
 
 pub struct Client {
     #[allow(dead_code)]
@@ -212,186 +211,6 @@ impl Client {
         }
         Ok(None)
     }
-
-    #[allow(dead_code)]
-    pub fn commit_changelog(&self, tag: Option<&str>) -> Result<String, Error> {
-        let mut index = self.git_repo.index()?;
-        index.add_path(Path::new(self.changelog()))?;
-        index.write()?;
-        let tree_id = index.write_tree()?;
-        let head = self.git_repo.head()?;
-        let parent = self.git_repo.find_commit(head.target().unwrap())?;
-        let sig = self.git_repo.signature()?;
-        let msg: String = self.settings.get("commit_message")?;
-
-        let commit_id = self.git_repo.commit(
-            Some("HEAD"),
-            &sig,
-            &sig,
-            &msg,
-            &self.git_repo.find_tree(tree_id)?,
-            &[&parent],
-        )?;
-
-        if let Some(version_tag) = tag {
-            let object = self.git_repo.find_object(commit_id, None)?;
-            let version_tag = format!("v{}", version_tag);
-            self.git_repo
-                .tag(&version_tag, &object, &sig, &version_tag, true)?;
-        };
-
-        Ok(commit_id.to_string())
-    }
-
-    #[allow(dead_code)]
-    pub fn commit_changelog_gpg(&mut self, tag: Option<&str>) -> Result<String, Error> {
-        let mut index = self.git_repo.index()?;
-        index.add_path(Path::new(self.changelog()))?;
-        index.write()?;
-        let tree_id = index.write_tree()?;
-        let head = self.git_repo.head()?;
-        let parent = self.git_repo.find_commit(head.target().unwrap())?;
-        let sig = self.git_repo.signature()?;
-        let msg: String = self.settings.get("commit_message")?;
-
-        let commit_buffer = self.git_repo.commit_create_buffer(
-            &sig,
-            &sig,
-            &msg,
-            &self.git_repo.find_tree(tree_id)?,
-            &[&parent],
-        )?;
-        let commit_str = std::str::from_utf8(&commit_buffer).unwrap();
-
-        let signature = self.git_repo.config()?.get_string(GIT_USER_SIGNATURE)?;
-
-        let short_sign = signature[12..].to_string();
-        log::trace!("Signature short: {short_sign}");
-
-        let gpg_args = vec!["--status-fd", "2", "-bsau", signature.as_str()];
-        log::trace!("gpg args: {:?}", gpg_args);
-
-        let mut cmd = Command::new("gpg");
-        cmd.args(gpg_args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = cmd.spawn()?;
-
-        let mut stdin = child.stdin.take().ok_or(Error::Stdin)?;
-        log::trace!("Secured access to stdin");
-
-        log::trace!("Input for signing:\n-----\n{}\n-----", commit_str);
-
-        stdin.write_all(commit_str.as_bytes())?;
-        log::trace!("writing complete");
-        drop(stdin); // close stdin to not block indefinitely
-        log::trace!("stdin closed");
-
-        let output = child.wait_with_output()?;
-        log::trace!("secured output");
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            log::trace!("stderr: {}", stderr);
-            return Err(Error::Stdout(stderr.to_string()));
-        }
-
-        let stderr = std::str::from_utf8(&output.stderr)?;
-
-        if !stderr.contains("\n[GNUPG:] SIG_CREATED ") {
-            return Err(Error::GpgError(
-                "failed to sign data, program gpg failed, SIG_CREATED not seen in stderr"
-                    .to_string(),
-            ));
-        }
-        log::trace!("Error checking completed without error");
-
-        let commit_signature = std::str::from_utf8(&output.stdout)?;
-
-        log::trace!("secured signed commit:\n{}", commit_signature);
-
-        let commit_id =
-            self.git_repo
-                .commit_signed(commit_str, commit_signature, Some("gpgsig"))?;
-
-        log::trace!("commit id: {}", commit_id);
-
-        if let Some(version_tag) = tag {
-            let object = self.git_repo.find_object(commit_id, None)?;
-            let version_tag = format!("v{}", version_tag);
-            self.git_repo
-                .tag(&version_tag, &object, &sig, &version_tag, true)?;
-        };
-
-        // manually advance to the new commit id
-        self.git_repo.head()?.set_target(commit_id, &msg)?;
-
-        log::trace!("head updated");
-
-        Ok(commit_id.to_string())
-    }
-
-    pub fn push_changelog(&self, version: Option<&str>) -> Result<(), Error> {
-        let mut remote = self.git_repo.find_remote("origin")?;
-        log::trace!("Pushing changes to {:?}", remote.name());
-        let mut callbacks = RemoteCallbacks::new();
-        callbacks.credentials(|_url, username_from_url, _allowed_types| {
-            Cred::ssh_key_from_agent(username_from_url.unwrap())
-        });
-        let mut connection = remote.connect_auth(Direction::Push, Some(callbacks), None)?;
-        let remote = connection.remote();
-
-        log::trace!("Branch: {:?} or {}", self.branch, self.branch());
-
-        let branch = match self.branch {
-            Some(ref branch) => {
-                log::trace!("*** found a branch: {}", branch);
-                branch
-            }
-            None => {
-                log::trace!("*** no branch found, defaulting to main");
-                "main"
-            }
-        };
-
-        let local_branch = self.git_repo.find_branch(branch, BranchType::Local)?;
-        log::trace!("Found branch: {}", local_branch.name()?.unwrap());
-
-        log::trace!("Got these refs: {:?}", Client::list_tags());
-
-        let branch_ref = local_branch.into_reference();
-        let mut push_refs = vec![branch_ref.name().unwrap()];
-        let tag_ref = if let Some(version_tag) = version {
-            log::trace!("Found version tag: {}", version_tag);
-            format!("/refs/tags/v{version_tag}")
-        } else {
-            String::from("")
-        };
-        if !tag_ref.is_empty() {
-            push_refs.push(&tag_ref);
-        }
-        log::trace!("Push refs: {:?}", push_refs);
-
-        remote.push(&push_refs, None)?;
-
-        Ok(())
-    }
-
-    fn list_tags() -> String {
-        let output = Command::new("ls")
-            .arg("-lR")
-            .arg(".git/refs")
-            .output()
-            .expect("ls of the git refs");
-        let stdout = output.stdout;
-
-        let string = String::from_utf8_lossy(&stdout);
-
-        string.to_string()
-    }
-
     /// Update the unreleased section to the changelog to `version`
     pub fn update_unreleased(&mut self, version: &str) -> Result<(), Error> {
         log::debug!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ mod pr_title;
 mod release_notes_provider;
 
 pub use client::Client;
+pub use client::GitOps;
 pub use error::Error;
 pub use pr_title::PrTitle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use config::Config;
 use env_logger::Env;
 use keep_a_changelog::ChangeKind;
-use pcu_lib::{Client, Error};
+use pcu_lib::{Client, Error, GitOps};
 
 use color_eyre::Result;
 

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -29,6 +29,7 @@ impl PrTitle {
         debug!("String to parse: `{}`", title);
 
         let pr_title = if let Some(captures) = re.captures(title) {
+            log::trace!("Captures: {:#?}", captures);
             let commit_type = captures.name("type").map(|m| m.as_str().to_string());
             let commit_scope = captures.name("scope").map(|m| m.as_str().to_string());
             let commit_breaking = captures.name("breaking").is_some();

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -87,43 +87,42 @@ impl PrTitle {
                 _ => {
                     section = ChangeKind::Changed;
                     entry = format!("{}-{}", self.commit_type.as_ref().unwrap(), entry);
+
+                    debug!("After checking for `feat` or `fix` type: `{}`", entry);
+
+                    if let Some(commit_scope) = &self.commit_scope {
+                        log::trace!("Checking scope `{}`", commit_scope);
+                        match commit_scope.as_str() {
+                            "security" => {
+                                section = ChangeKind::Security;
+                                entry = format!("Security: {}", self.title);
+                            }
+                            "deps" => {
+                                section = ChangeKind::Security;
+                                entry = format!("Dependencies: {}", self.title);
+                            }
+                            "remove" => {
+                                section = ChangeKind::Removed;
+                                entry = format!("Removed: {}", self.title);
+                            }
+                            "deprecate" => {
+                                section = ChangeKind::Deprecated;
+                                entry = format!("Deprecated: {}", self.title);
+                            }
+                            _ => {
+                                section = ChangeKind::Changed;
+                                let split_description = entry.splitn(2, '-').collect::<Vec<&str>>();
+                                log::trace!("Split description: {:#?}", split_description);
+                                entry = format!(
+                                    "{}({})-{}",
+                                    split_description[0], commit_scope, split_description[1]
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
-
-        debug!("After checking type `{}`", entry);
-
-        if let Some(commit_scope) = &self.commit_scope {
-            log::trace!("Checking scope `{}`", commit_scope);
-            match commit_scope.as_str() {
-                "security" => {
-                    section = ChangeKind::Security;
-                    entry = format!("Security: {}", self.title);
-                }
-                "deps" => {
-                    section = ChangeKind::Security;
-                    entry = format!("Dependencies: {}", self.title);
-                }
-                "remove" => {
-                    section = ChangeKind::Removed;
-                    entry = format!("Removed: {}", self.title);
-                }
-                "deprecate" => {
-                    section = ChangeKind::Deprecated;
-                    entry = format!("Deprecated: {}", self.title);
-                }
-                _ => {
-                    section = ChangeKind::Changed;
-                    let split_description = entry.splitn(2, '-').collect::<Vec<&str>>();
-                    log::trace!("Split description: {:#?}", split_description);
-                    entry = format!(
-                        "{}({})-{}",
-                        split_description[0], commit_scope, split_description[1]
-                    );
-                }
-            }
-        }
-
         debug!("After checking scope `{}`", entry);
 
         if self.commit_breaking {

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -118,9 +118,7 @@ impl PrTitle {
                     log::trace!("Split description: {:#?}", split_description);
                     entry = format!(
                         "{}({})-{}",
-                        split_description[0],
-                        self.commit_scope.as_ref().unwrap(),
-                        split_description[1]
+                        split_description[0], commit_scope, split_description[1]
                     );
                 }
             }

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -93,6 +93,7 @@ impl PrTitle {
         debug!("After checking type `{}`", entry);
 
         if let Some(commit_scope) = &self.commit_scope {
+            log::trace!("Checking scope `{}`", commit_scope);
             match commit_scope.as_str() {
                 "security" => {
                     section = ChangeKind::Security;
@@ -113,6 +114,7 @@ impl PrTitle {
                 _ => {
                     section = ChangeKind::Changed;
                     let split_description = entry.splitn(2, '-').collect::<Vec<&str>>();
+                    log::trace!("Split description: {:#?}", split_description);
                     entry = format!(
                         "{}({})-{}",
                         split_description[0],

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -83,7 +83,13 @@ impl PrTitle {
         if let Some(commit_type) = &self.commit_type {
             match commit_type.as_str() {
                 "feat" => section = ChangeKind::Added,
-                "fix" => section = ChangeKind::Fixed,
+                "fix" => {
+                    section = ChangeKind::Fixed;
+                    if let Some(commit_scope) = &self.commit_scope {
+                        log::trace!("Found scope `{}`", commit_scope);
+                        entry = format!("{}: {}", commit_scope, self.title);
+                    }
+                }
                 _ => {
                     section = ChangeKind::Changed;
                     entry = format!("{}-{}", self.commit_type.as_ref().unwrap(), entry);
@@ -405,8 +411,8 @@ mod tests {
         "fix(security): Fix security vulnerability",
         None,
         None,
-        ChangeKind::Security,
-        "Security: Fix security vulnerability"
+        ChangeKind::Fixed,
+        "security: Fix security vulnerability"
     )]
     #[case(
         "chore(deps): Update dependencies",


### PR DESCRIPTION
* - Create a new module `git_ops.rs` and move git related operations from `client/mod.rs` to the new module
* - Implement `GitOps` trait for `Client` in `git_ops.rs`
* - Update `client/mod.rs` to import and expose `GitOps`
* - Update `lib.rs` to expose `GitOps`
* - Update `main.rs` to import `GitOps`

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
