### PR TITLE
feat: add ChangelogParseOptions to Client struct and default value for version_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - extract git operations to a separate module(pr [#243])
 - add new module ops(pr [#253])
 - add new module and ReleaseUnreleased trait and implementation(pr [#254])
+- add ChangelogParseOptions to Client struct and default value for version_prefix(pr [#255])
 
 ### Changed
 
@@ -432,29 +433,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#252]: https://github.com/jerus-org/pcu/pull/252
 [#253]: https://github.com/jerus-org/pcu/pull/253
 [#254]: https://github.com/jerus-org/pcu/pull/254
-[Unreleased]: https://github.com/jerus-org/pcu/compare/0.1.24...HEAD
-[0.1.24]: https://github.com/jerus-org/pcu/compare/0.1.23...0.1.24
-[0.1.23]: https://github.com/jerus-org/pcu/compare/0.1.22...0.1.23
-[0.1.22]: https://github.com/jerus-org/pcu/compare/0.1.21...0.1.22
-[0.1.21]: https://github.com/jerus-org/pcu/compare/0.1.20...0.1.21
-[0.1.20]: https://github.com/jerus-org/pcu/compare/0.1.19...0.1.20
-[0.1.19]: https://github.com/jerus-org/pcu/compare/0.1.18...0.1.19
-[0.1.18]: https://github.com/jerus-org/pcu/compare/0.1.17...0.1.18
-[0.1.17]: https://github.com/jerus-org/pcu/compare/0.1.16...0.1.17
-[0.1.16]: https://github.com/jerus-org/pcu/compare/0.1.15...0.1.16
-[0.1.15]: https://github.com/jerus-org/pcu/compare/0.1.14...0.1.15
-[0.1.14]: https://github.com/jerus-org/pcu/compare/0.1.13...0.1.14
-[0.1.13]: https://github.com/jerus-org/pcu/compare/0.1.12...0.1.13
-[0.1.12]: https://github.com/jerus-org/pcu/compare/0.1.11...0.1.12
-[0.1.11]: https://github.com/jerus-org/pcu/compare/0.1.10...0.1.11
-[0.1.10]: https://github.com/jerus-org/pcu/compare/0.1.9...0.1.10
-[0.1.9]: https://github.com/jerus-org/pcu/compare/0.1.8...0.1.9
-[0.1.8]: https://github.com/jerus-org/pcu/compare/0.1.7...0.1.8
-[0.1.7]: https://github.com/jerus-org/pcu/compare/0.1.6...0.1.7
-[0.1.6]: https://github.com/jerus-org/pcu/compare/0.1.5...0.1.6
-[0.1.5]: https://github.com/jerus-org/pcu/compare/0.1.4...0.1.5
-[0.1.4]: https://github.com/jerus-org/pcu/compare/0.1.3...0.1.4
-[0.1.3]: https://github.com/jerus-org/pcu/compare/0.1.2...0.1.3
-[0.1.2]: https://github.com/jerus-org/pcu/compare/0.1.1...0.1.2
-[0.1.1]: https://github.com/jerus-org/pcu/compare/0.1.0...0.1.1
-[0.1.0]: https://github.com/jerus-org/pcu/releases/tag/0.1.0
+[#255]: https://github.com/jerus-org/pcu/pull/255
+[Unreleased]: https://github.comjerus-org/pcu/compare/v0.1.24...main
+[0.1.24]: https://github.comjerus-org/pcu/compare/v0.1.23...v0.1.24
+[0.1.23]: https://github.comjerus-org/pcu/compare/v0.1.22...v0.1.23
+[0.1.22]: https://github.comjerus-org/pcu/compare/v0.1.21...v0.1.22
+[0.1.21]: https://github.comjerus-org/pcu/compare/v0.1.20...v0.1.21
+[0.1.20]: https://github.comjerus-org/pcu/compare/v0.1.19...v0.1.20
+[0.1.19]: https://github.comjerus-org/pcu/compare/v0.1.18...v0.1.19
+[0.1.18]: https://github.comjerus-org/pcu/compare/v0.1.17...v0.1.18
+[0.1.17]: https://github.comjerus-org/pcu/compare/v0.1.16...v0.1.17
+[0.1.16]: https://github.comjerus-org/pcu/compare/v0.1.15...v0.1.16
+[0.1.15]: https://github.comjerus-org/pcu/compare/v0.1.14...v0.1.15
+[0.1.14]: https://github.comjerus-org/pcu/compare/v0.1.13...v0.1.14
+[0.1.13]: https://github.comjerus-org/pcu/compare/v0.1.12...v0.1.13
+[0.1.12]: https://github.comjerus-org/pcu/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.comjerus-org/pcu/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.comjerus-org/pcu/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.comjerus-org/pcu/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.comjerus-org/pcu/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.comjerus-org/pcu/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.comjerus-org/pcu/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.comjerus-org/pcu/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.comjerus-org/pcu/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.comjerus-org/pcu/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.comjerus-org/pcu/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.comjerus-org/pcu/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.comjerus-org/pcu/releases/tag/v0.1.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,7 @@ fn get_settings(cmd: Commands) -> Result<Config, Error> {
         .set_default("reponame", "CIRCLE_PROJECT_REPONAME")?
         .set_default("commit_message", "chore: update changelog")?
         .set_default("scs_root", "https://github.com/")?
+        .set_default("version_prefix", "v")?
         // Add in settings from pcu.toml if it exists
         .add_source(config::File::with_name("pcu.toml").required(false))
         // Add in settings from the environment (with a prefix of PCU)

--- a/src/ops/make_release.rs
+++ b/src/ops/make_release.rs
@@ -125,16 +125,7 @@ impl MakeRelease for Client {
         log::debug!("Making release {version}");
 
         if update_changelog {
-            let svs_root = self
-                .settings
-                .get("svs_root")
-                .unwrap_or_else(|_| "https://github.com".to_string());
-            let repo_url = Some(format!("{}{}/{}", svs_root, self.owner, self.repo));
-            let opts = ChangelogParseOptions {
-                url: repo_url,
-                head: Some("main".to_string()),
-                tag_prefix: Some("v".to_string()),
-            };
+            let opts = self.changelog_parse_options.clone();
 
             let mut change_log = Changelog::parse_from_file(self.changelog_as_str(), Some(opts))
                 .map_err(|e| Error::KeepAChangelog(e.to_string()))?;

--- a/src/ops/update_from_pr.rs
+++ b/src/ops/update_from_pr.rs
@@ -33,9 +33,11 @@ impl UpdateFromPr for Client {
             return Err(Error::NoChangeLogFileFound);
         }
 
+        let opts = self.changelog_parse_options.clone();
+
         if let Some(update) = &mut self.changelog_update {
             #[allow(clippy::needless_question_mark)]
-            return Ok(update.update_changelog(&self.changelog)?);
+            return Ok(update.update_changelog(&self.changelog, opts)?);
         }
         Ok(None)
     }

--- a/src/pr_title.rs
+++ b/src/pr_title.rs
@@ -168,6 +168,7 @@ impl PrTitle {
     pub fn update_changelog(
         &mut self,
         log_file: &OsStr,
+        opts: ChangelogParseOptions,
     ) -> Result<Option<(ChangeKind, String)>, Error> {
         let Some(log_file) = log_file.to_str() else {
             return Err(Error::InvalidPath(log_file.to_owned()));
@@ -196,16 +197,8 @@ impl PrTitle {
             } else {
                 log::trace!("The changelog exists but does not contain the entry!");
             }
-            let options = if repo_url.is_some() {
-                Some(ChangelogParseOptions {
-                    url: repo_url.clone(),
-                    ..Default::default()
-                })
-            } else {
-                None
-            };
 
-            Changelog::parse_from_file(log_file, options)
+            Changelog::parse_from_file(log_file, Some(opts))
                 .map_err(|e| Error::KeepAChangelog(e.to_string()))?
         } else {
             log::trace!("The changelog does not exist! Create a default changelog.");
@@ -511,7 +504,10 @@ mod tests {
         };
 
         let file_name = &file_name.into_os_string();
-        pr_title.update_changelog(file_name)?;
+
+        let opts = ChangelogParseOptions::default();
+
+        pr_title.update_changelog(file_name, opts)?;
 
         let actual_content = fs::read_to_string(file_name)?;
 
@@ -552,7 +548,9 @@ mod tests {
         };
 
         let file_name = &file_name.into_os_string();
-        pr_title.update_changelog(file_name)?;
+        let opts = ChangelogParseOptions::default();
+
+        pr_title.update_changelog(file_name, opts)?;
 
         let mut pr_title = PrTitle::parse(
             "chore(config.yml): update jerus-org/circleci-toolkit orb version to 0.4.0",
@@ -562,7 +560,9 @@ mod tests {
         pr_title.calculate_section_and_entry();
 
         let file_name = &file_name.to_os_string();
-        pr_title.update_changelog(file_name)?;
+        let opts = ChangelogParseOptions::default();
+
+        pr_title.update_changelog(file_name, opts)?;
 
         let actual_content = fs::read_to_string(file_name)?;
 


### PR DESCRIPTION
* feat(client/mod.rs): add ChangelogParseOptions to Client struct
* feat(main.rs): add default value for version_prefix in settings
* refactor(make_release.rs, update_from_pr.rs, pr_title.rs): use ChangelogParseOptions from Client struct
* test(pr_title.rs): update tests to use ChangelogParseOptions

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
