### PR TITLE
fix: remove redundant GitHubAPI instantiation in new_pull_request_opt function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ workflows:
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           install_from_github: true
-          pcu_verbosity: "-vvvv"
+          pcu_verbosity: "-vvv"
 
   on_success:
     when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deps: update rust crate clap-verbosity-flag to 2.2.1(pr [#267])
 - deps: update rust crate env_logger to 0.11.5(pr [#269])
 - deps: update rust crate regex to 1.10.6(pr [#270])
+- remove redundant GitHubAPI instantiation in new_pull_request_opt function(pr [#274])
 
 ## [0.1.26] - 2024-08-10
 
@@ -489,6 +490,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#271]: https://github.com/jerus-org/pcu/pull/271
 [#272]: https://github.com/jerus-org/pcu/pull/272
 [#273]: https://github.com/jerus-org/pcu/pull/273
+[#274]: https://github.com/jerus-org/pcu/pull/274
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.1.26...HEAD
 [0.1.26]: https://github.com/jerus-org/pcu/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/jerus-org/pcu/compare/v0.1.24...v0.1.25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,12 +196,13 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1211,6 +1212,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b6996d4597aff355019ba743f33dada3f1d74a54f7c008df9d617dfdc64ccf"
 dependencies = [
+ "chrono",
  "octocrate-core",
  "octocrate-types",
  "serde",
@@ -1239,6 +1241,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fad2fd851d7504794b4ef9782b00cd34bbbc409d2ab3695a4e993223fa3d8ea"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "typed-builder",
@@ -1775,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -1825,6 +1828,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,12 @@ clap = "4.5.15"
 clap-verbosity-flag = "2.2.1"
 config = "0.14.0"
 chrono = "0.4.38"
-octocrate = { version = "2.0.1", features = ["pulls", "repos", "rustls-tls"], default-features = false }
+octocrate = { version = "2.0.1", features = [
+    "apps",
+    "pulls",
+    "repos",
+    "rustls-tls",
+], default-features = false }
 
 [dev-dependencies]
 log4rs_test_utils = "0.2.3"

--- a/src/client/pull_request.rs
+++ b/src/client/pull_request.rs
@@ -53,7 +53,7 @@ impl PullRequest {
         // Get the github pull release and store the title in the client struct
         // The title can be edited by the calling programme if desired before creating the prtitle
 
-        log::debug!("Using Octocrate instance");
+        log::debug!("********* Using Octocrate instance");
         let pr = api.pulls.get(&owner, &repo, pr_number).send().await?;
 
         let title = pr.title;


### PR DESCRIPTION
* refactor(config.yml): reduce pcu_verbosity level from "-vvvv" to "-vvv"
* refactor(client/mod.rs): move git_api instantiation to top of Client implementation
* feat(client/mod.rs): add debug log when getting GitHub API instance
* refactor(client/mod.rs): change debug log message when using personal access token for authentication
* refactor(client/pull_request.rs): pass GitHubAPI instance to new_pull_request_opt function
* refactor(client/pull_request.rs): remove redundant GitHubAPI instantiation in new_pull_request_opt function

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
