### PR TITLE
refactor: change print_changelog function to return string instead of printing directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ci-upgrade jerus-org/circleci-toolkit orb version from 0.25.0 to 1.0.0(pr [#268])
 - refactor-remove settings field from Client struct, add git_api, default_branch, commit_message fields(pr [#271])
 - ci-increase pcu_verbosity level from -vvv to -vvvv(pr [#276])
+- refactor-change print_changelog function to return string instead of printing directly(pr [#280])
 
 ### Fixed
 
@@ -501,6 +502,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#277]: https://github.com/jerus-org/pcu/pull/277
 [#278]: https://github.com/jerus-org/pcu/pull/278
 [#279]: https://github.com/jerus-org/pcu/pull/279
+[#280]: https://github.com/jerus-org/pcu/pull/280
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.1.26...HEAD
 [0.1.26]: https://github.com/jerus-org/pcu/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/jerus-org/pcu/compare/v0.1.24...v0.1.25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1306,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 name = "pcu"
 version = "0.1.26"
 dependencies = [
+ "ansi_term",
  "chrono",
  "clap",
  "clap-verbosity-flag",

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,10 @@ async fn run_pull_request(sign: Sign, args: PullRequest) -> Result<ClState> {
 
     log::debug!("Changelog file name: {}", client.changelog_as_str());
 
-    if log::log_enabled!(log::Level::Trace) {
-        print_changelog(client.changelog_as_str(), client.line_limit());
-    };
+    log::trace!(
+        "{}",
+        print_changelog(client.changelog_as_str(), client.line_limit())
+    );
 
     let report = client.repo_status()?;
     log::debug!("Before commit:Repo state: {report}");
@@ -154,9 +155,11 @@ async fn run_release(sign: Sign, args: Release) -> Result<ClState> {
         client.release_unreleased(&version)?;
         log::debug!("Changelog file name: {}", client.changelog_as_str());
 
-        if log::log_enabled!(log::Level::Trace) {
-            print_changelog(client.changelog_as_str(), client.line_limit());
-        };
+        log::trace!(
+            "{}",
+            print_changelog(client.changelog_as_str(), client.line_limit())
+        );
+
         let report = client.repo_status()?;
         log::debug!("Before commit:Repo state: {report}");
         log::debug!("before commit:Branch status: {}", client.branch_status()?);
@@ -184,23 +187,27 @@ async fn run_release(sign: Sign, args: Release) -> Result<ClState> {
     Ok(ClState::Updated)
 }
 
-fn print_changelog(changelog_path: &str, mut line_limit: usize) {
+fn print_changelog(changelog_path: &str, mut line_limit: usize) -> String {
+    let mut output = String::new();
+
     if let Ok(change_log) = fs::read_to_string(changelog_path) {
         let mut line_count = 0;
         if line_limit == 0 {
             line_limit = change_log.lines().count();
         };
 
-        println!("\n*****Changelog*****:\n----------------------------");
+        output.push_str("\n*****Changelog*****:\n----------------------------");
         for line in change_log.lines() {
-            println!("{line}");
+            output.push_str(format!("{line}\n").as_str());
             line_count += 1;
             if line_count >= line_limit {
                 break;
             }
         }
-        println!("----------------------------\n",);
+        output.push_str("----------------------------\n");
     };
+
+    output
 }
 
 fn get_logging(level: log::LevelFilter) -> env_logger::Builder {


### PR DESCRIPTION
* refactor(main.rs): change print_changelog function to return string instead of printing directly
* refactor(main.rs): use log::trace for changelog output instead of checking log level manually

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
