### PR TITLE
feat: add stage_files function to GitOps trait and implement it in Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: add push command to CLI to push any changes to the remote repository(pr [#282])
 - list the unstaged files(pr [#283])
+- add stage_files function to GitOps trait and implement it in Client(pr [#284])
 
 ### Changed
 
@@ -517,6 +518,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#281]: https://github.com/jerus-org/pcu/pull/281
 [#282]: https://github.com/jerus-org/pcu/pull/282
 [#283]: https://github.com/jerus-org/pcu/pull/283
+[#284]: https://github.com/jerus-org/pcu/pull/284
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/jerus-org/pcu/compare/v0.1.26...v0.2.0
 [0.1.26]: https://github.com/jerus-org/pcu/compare/v0.1.25...v0.1.26

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -153,6 +153,8 @@ async fn run_push(sign: Sign, args: Push) -> Result<ClState> {
 
     log::info!("Stage the changes for commit");
 
+    client.stage_files(files_in_workdir)?;
+
     log::debug!("{}", Style::new().bold().underline().paint("Check Staged"));
     log::debug!("WorkDir files:\n\t{:?}", client.repo_files_not_staged()?);
 

--- a/src/lib/ops/git_ops.rs
+++ b/src/lib/ops/git_ops.rs
@@ -17,6 +17,7 @@ pub trait GitOps {
     fn repo_status(&self) -> Result<String, Error>;
     fn repo_files_not_staged(&self) -> Result<Vec<String>, Error>;
     fn repo_files_staged(&self) -> Result<Vec<String>, Error>;
+    fn stage_files(&self, files: Vec<String>) -> Result<(), Error>;
     fn create_tag(&self, tag: &str, commit_id: Oid, sig: &Signature) -> Result<(), Error>;
     #[allow(async_fn_in_trait)]
     async fn get_commitish_for_tag(&self, version: &str) -> Result<String, Error>;
@@ -267,6 +268,17 @@ impl GitOps for Client {
         Ok(files)
     }
 
+    fn stage_files(&self, files: Vec<String>) -> Result<(), Error> {
+        let mut index = self.git_repo.index()?;
+
+        for file in files {
+            index.add_path(Path::new(&file))?;
+        }
+
+        index.write()?;
+
+        Ok(())
+    }
     fn branch_list(&self) -> Result<String, Error> {
         let branches = self.git_repo.branches(None)?;
 


### PR DESCRIPTION
* feat(cli/main.rs, lib/ops/git_ops.rs): add stage_files function to GitOps trait and implement it in Client
* feat(cli/main.rs): stage files in workdir before checking staged files

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
