### PR TITLE
feat: add commit_staged function to GitOps trait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,43 +179,18 @@ jobs:
         type: string
         description: |
           The fingerprint of the ssh key to use
-      # gpg_key:
-      #   type: env_var_name
-      #   default: BOT_GPG_KEY
-      #   description: "The base64 encoded GPG key"
-      # gpg_trust:
-      #   type: env_var_name
-      #   default: BOT_TRUST
-      #   description: "The trust associated with the GPG key"
-      # user_email:
-      #   type: env_var_name
-      #   default: BOT_USER_EMAIL
-      #   description: "The user email associated with the GPG key"
-      # user_name:
-      #   type: env_var_name
-      #   default: BOT_USER_NAME
-      #   description: "The user name associated with the GPG key"
-      # sign_key:
-      #   type: env_var_name
-      #   default: BOT_SIGN_KEY
-      #   description: "The GPG key id associated with the GPG key"
       pcu_verbosity:
         type: string
         default: "-vv"
         description: "The verbosity of the pcu command"
-      # pcu_halt_signal:
-      #   type: string
-      #   default: "halt"
-      #   description: "Word expected to signal an early exit"
-      # install_from_github:
-      #   type: boolean
-      #   default: false
-      #   description: "Install pcu from github"
-      # update_log_option:
-      #   type: enum
-      #   enum: ["halt", "pipeline"]
-      #   default: "pipeline"
-      #   description: "The option to halt or continue with new pipeline when a change log does not need to be updated"
+      pcu_semver:
+        type: boolean
+        default: false
+        description: "Whether or not set the semver version flag"
+      pcu_commit_message:
+        type: string
+        default: "chore: test push"
+        description: "The commit message to use for the pcu test push"
     steps:
       - checkout
       - add_ssh_keys:
@@ -246,7 +221,11 @@ jobs:
           name: Test push
           command: |
             set -ex
-            result=$(pcu << parameters.pcu_verbosity >> push)
+            if [ "<< parameters.pcu_semver >>" == "true"  ] ; then
+              pcu << parameters.pcu_verbosity >> push --commit-message << parameters.pcu_commit_message >> --semver $SEMVER
+            else
+              pcu << parameters.pcu_verbosity >> push --commit-message << parameters.pcu_commit_message >> 
+            fi
 workflows:
   check_last_commit:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,9 +172,6 @@ jobs:
   test-push:
     executor: rust-env
     parameters:
-      # min_rust_version:
-      #   type: string
-      #   description: "The minimum version of the rust compiler to use"
       ssh_fingerprint:
         type: string
         description: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,9 +222,9 @@ jobs:
           command: |
             set -ex
             if [ "<< parameters.pcu_semver >>" == "true"  ] ; then
-              pcu << parameters.pcu_verbosity >> push --commit-message << parameters.pcu_commit_message >> --semver $SEMVER
+              pcu << parameters.pcu_verbosity >> push --commit-message "<< parameters.pcu_commit_message >>" --semver $SEMVER
             else
-              pcu << parameters.pcu_verbosity >> push --commit-message << parameters.pcu_commit_message >> 
+              pcu << parameters.pcu_verbosity >> push --commit-message "<< parameters.pcu_commit_message >>"
             fi
 workflows:
   check_last_commit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: add push command to CLI to push any changes to the remote repository(pr [#282])
 - list the unstaged files(pr [#283])
 - add stage_files function to GitOps trait and implement it in Client(pr [#284])
-- add commit_staged function to GitOps trait(pr [#285])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: add push command to CLI to push any changes to the remote repository(pr [#282])
 - list the unstaged files(pr [#283])
 - add stage_files function to GitOps trait and implement it in Client(pr [#284])
+- add commit_staged function to GitOps trait(pr [#285])
 
 ### Changed
 
@@ -519,6 +520,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#282]: https://github.com/jerus-org/pcu/pull/282
 [#283]: https://github.com/jerus-org/pcu/pull/283
 [#284]: https://github.com/jerus-org/pcu/pull/284
+[#285]: https://github.com/jerus-org/pcu/pull/285
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/jerus-org/pcu/compare/v0.1.26...v0.2.0
 [0.1.26]: https://github.com/jerus-org/pcu/compare/v0.1.25...v0.1.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- add commit_staged function to GitOps trait(pr [#285])
+
 ## [0.3.0] - 2024-08-17
 
 ### Added
@@ -519,6 +525,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#282]: https://github.com/jerus-org/pcu/pull/282
 [#283]: https://github.com/jerus-org/pcu/pull/283
 [#284]: https://github.com/jerus-org/pcu/pull/284
+[#285]: https://github.com/jerus-org/pcu/pull/285
+[Unreleased]: https://github.com/jerus-org/pcu/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/jerus-org/pcu/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jerus-org/pcu/compare/v0.1.26...v0.2.0
 [0.1.26]: https://github.com/jerus-org/pcu/compare/v0.1.25...v0.1.26

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -51,7 +51,27 @@ pub struct Release {
 }
 
 #[derive(Debug, Parser, Clone)]
-pub struct Push {}
+pub struct Push {
+    /// Semantic version number for a tag
+    #[arg(short, long)]
+    pub semver: String,
+    /// Message to add to the commit when pushing
+    #[arg(short, long)]
+    commit_message: String,
+}
+
+impl Push {
+    pub fn commit_message(&self) -> &str {
+        &self.commit_message
+    }
+
+    pub fn tag_opt(&self) -> Option<&str> {
+        if self.semver.is_empty() {
+            return None;
+        }
+        Some(&self.semver)
+    }
+}
 
 pub enum ClState {
     Updated,

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,13 +1,7 @@
 use std::fmt::Display;
 
-use clap::{Parser, Subcommand, ValueEnum};
-
-#[derive(ValueEnum, Debug, Default, Clone)]
-pub enum Sign {
-    #[default]
-    Gpg,
-    None,
-}
+use clap::{Parser, Subcommand};
+use pcu_lib::Sign;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -54,7 +54,7 @@ pub struct Release {
 pub struct Push {
     /// Semantic version number for a tag
     #[arg(short, long)]
-    pub semver: String,
+    pub semver: Option<String>,
     /// Message to add to the commit when pushing
     #[arg(short, long)]
     commit_message: String,
@@ -66,10 +66,10 @@ impl Push {
     }
 
     pub fn tag_opt(&self) -> Option<&str> {
-        if self.semver.is_empty() {
-            return None;
+        if let Some(semver) = &self.semver {
+            return Some(semver);
         }
-        Some(&self.semver)
+        None
     }
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use config::Config;
 use env_logger::Env;
 use keep_a_changelog::ChangeKind;
-use pcu_lib::{Client, Error, GitOps, MakeRelease, UpdateFromPr};
+use pcu_lib::{Client, Error, GitOps, MakeRelease, Sign, UpdateFromPr};
 
 use color_eyre::Result;
 
@@ -16,7 +16,7 @@ const GITHUB_PAT: &str = "GITHUB_TOKEN";
 
 mod cli;
 
-use cli::{ClState, Cli, Commands, PullRequest, Push, Release, Sign};
+use cli::{ClState, Cli, Commands, PullRequest, Push, Release};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -163,16 +163,20 @@ async fn run_push(sign: Sign, args: Push) -> Result<ClState> {
     log::debug!("Staged files:\n\t{:?}", files_staged_for_commit);
     log::debug!("Branch status: {}", client.branch_status()?);
 
-    match sign {
-        Sign::Gpg => {
-            log::info!("Commit and sign the commit with GPG")
-            // client.commit_changelog_gpg(None)?;
-        }
-        Sign::None => {
-            log::info!("Commit without signing the commit")
-            //     client.commit_changelog(None)?;
-        }
-    }
+    log::info!("Commit the staged changes");
+
+    client.commit_staged(sign, None)?;
+
+    // match sign {
+    //     Sign::Gpg => {
+    //         log::info!("Commit and sign the commit with GPG")
+    //         // client.commit_changelog_gpg(None)?;
+    //     }
+    //     Sign::None => {
+    //         log::info!("Commit without signing the commit")
+    //         //     client.commit_changelog(None)?;
+    //     }
+    // }
 
     log::debug!(
         "{}",

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -165,7 +165,7 @@ async fn run_push(sign: Sign, args: Push) -> Result<ClState> {
 
     log::info!("Commit the staged changes");
 
-    client.commit_staged(sign, None)?;
+    client.commit_staged(sign, args.commit_message(), args.tag_opt())?;
 
     // match sign {
     //     Sign::Gpg => {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -8,5 +8,6 @@ pub use client::Client;
 pub use error::Error;
 pub use ops::GitOps;
 pub use ops::MakeRelease;
+pub use ops::Sign;
 pub use ops::UpdateFromPr;
 pub use pr_title::PrTitle;

--- a/src/lib/ops/git_ops.rs
+++ b/src/lib/ops/git_ops.rs
@@ -26,7 +26,7 @@ pub trait GitOps {
     fn repo_files_not_staged(&self) -> Result<Vec<String>, Error>;
     fn repo_files_staged(&self) -> Result<Vec<String>, Error>;
     fn stage_files(&self, files: Vec<String>) -> Result<(), Error>;
-    fn commit_staged(&self, sign: Sign, tag: Option<&str>) -> Result<String, Error>;
+    fn commit_staged(&self, sign: Sign, tag: Option<&str>) -> Result<(), Error>;
     fn create_tag(&self, tag: &str, commit_id: Oid, sig: &Signature) -> Result<(), Error>;
     #[allow(async_fn_in_trait)]
     async fn get_commitish_for_tag(&self, version: &str) -> Result<String, Error>;
@@ -289,11 +289,9 @@ impl GitOps for Client {
         Ok(())
     }
 
-    fn commit_staged(&self, sign: Sign, tag: Option<&str>) -> Result<String, Error> {
+    fn commit_staged(&self, sign: Sign, tag: Option<&str>) -> Result<(), Error> {
         log::trace!("Commit staged with sign {sign:?}");
         let mut index = self.git_repo.index()?;
-        index.add_path(Path::new(self.changelog_as_str()))?;
-        index.write()?;
         let tree_id = index.write_tree()?;
         let head = self.git_repo.head()?;
         let parent = self.git_repo.find_commit(head.target().unwrap())?;
@@ -313,7 +311,7 @@ impl GitOps for Client {
             self.create_tag(&version_tag, commit_id, &sig)?;
         };
 
-        Ok(commit_id.to_string())
+        Ok(())
     }
 
     fn branch_list(&self) -> Result<String, Error> {

--- a/src/lib/ops/mod.rs
+++ b/src/lib/ops/mod.rs
@@ -3,5 +3,6 @@ mod make_release;
 mod update_from_pr;
 
 pub use git_ops::GitOps;
+pub use git_ops::Sign;
 pub use make_release::MakeRelease;
 pub use update_from_pr::UpdateFromPr;


### PR DESCRIPTION
* refactor(cli.rs, main.rs, lib.rs, git_ops.rs, mod.rs): move Sign enum from cli.rs to git_ops.rs
* feat(git_ops.rs): add commit_staged function to GitOps trait
* refactor(main.rs): replace sign match with commit_staged function call

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
