### PR TITLE
fix: integrate get_authenticated_remote into push_commit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add push_commit method and refactor branch method to branch_or_main(pr [#286])
 
+### Fixed
+
+- integrate get_authenticated_remote into push_commit method(pr [#287])
+
 ## [0.4.0] - 2024-08-17
 
 ### Added
@@ -533,6 +537,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#284]: https://github.com/jerus-org/pcu/pull/284
 [#285]: https://github.com/jerus-org/pcu/pull/285
 [#286]: https://github.com/jerus-org/pcu/pull/286
+[#287]: https://github.com/jerus-org/pcu/pull/287
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/jerus-org/pcu/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jerus-org/pcu/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
* refactor(git_ops.rs): remove get_authenticated_remote method and integrate its functionality into push_commit method
* style(git_ops.rs): remove unnecessary imports and adjust code formatting

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
