### PR TITLE
fix(graphql): correct typo in 'labelable' struct field name in label_pr.rs

### DIFF
--- a/src/lib/client/graphql/label_pr.rs
+++ b/src/lib/client/graphql/label_pr.rs
@@ -21,7 +21,7 @@ struct Vars {
 
 #[derive(Deserialize, Debug, Clone)]
 struct Data {
-    lableable: LabelAble,
+    labelable: LabelAble,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
