### PR TITLE
♻️ refactor(cli): modularize commit command handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔧 chore(structure)-reorganize directory structure(pr [#485])
 - ♻️ refactor(cli)-modularize pull request handling(pr [#486])
+- ♻️ refactor(cli)-modularize commit command handling(pr [#487])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1146,6 +1147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#484]: https://github.com/jerus-org/pcu/pull/484
 [#485]: https://github.com/jerus-org/pcu/pull/485
 [#486]: https://github.com/jerus-org/pcu/pull/486
+[#487]: https://github.com/jerus-org/pcu/pull/487
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -12,7 +12,7 @@ const LOG_ENV_VAR: &str = "RUST_LOG";
 const LOG_STYLE_ENV_VAR: &str = "RUST_LOG_STYLE";
 const GITHUB_PAT: &str = "GITHUB_TOKEN";
 
-use pcu::cli::{CIExit, Cli, Commands, Commit, Label, Push, Release};
+use pcu::cli::{CIExit, Cli, Commands, Label, Push, Release};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     let res = match cmd {
         Commands::Pr(pr_args) => pcu::cli::run_pull_request(sign, pr_args).await,
-        Commands::Commit(commit_args) => run_commit(sign, commit_args).await,
+        Commands::Commit(commit_args) => pcu::cli::run_commit(sign, commit_args).await,
         Commands::Push(push_args) => run_push(push_args).await,
         Commands::Label(label_args) => run_label(label_args).await,
         Commands::Release(rel_args) => run_release(sign, rel_args).await,
@@ -52,21 +52,6 @@ async fn main() -> Result<()> {
     };
 
     Ok(())
-}
-
-async fn run_commit(sign: Sign, args: Commit) -> Result<CIExit> {
-    let client = get_client(Commands::Commit(args.clone())).await?;
-
-    commit_changed_files(
-        &client,
-        sign,
-        args.commit_message(),
-        &args.prefix,
-        args.tag_opt(),
-    )
-    .await?;
-
-    Ok(CIExit::Committed)
 }
 
 async fn commit_changed_files(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
+mod commit;
 mod pull_request;
+
+pub use commit::run_commit;
 pub use pull_request::run_pull_request;
 
 use std::{env, fmt::Display, fs};

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -1,0 +1,20 @@
+use crate::Sign;
+
+use color_eyre::Result;
+
+use super::{CIExit, Commands, Commit};
+
+pub async fn run_commit(sign: Sign, args: Commit) -> Result<CIExit> {
+    let client = super::get_client(Commands::Commit(args.clone())).await?;
+
+    super::commit_changed_files(
+        &client,
+        sign,
+        args.commit_message(),
+        &args.prefix,
+        args.tag_opt(),
+    )
+    .await?;
+
+    Ok(CIExit::Committed)
+}


### PR DESCRIPTION
- move run_commit function to a separate module for better organization
- update main.rs to use the new module path for run_commit function

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
