### PR TITLE
♻️ refactor(cli): modularize push command handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(structure)-reorganize directory structure(pr [#485])
 - ♻️ refactor(cli)-modularize pull request handling(pr [#486])
 - ♻️ refactor(cli)-modularize commit command handling(pr [#487])
+- ♻️ refactor(cli)-modularize push command handling(pr [#488])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1148,6 +1149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#485]: https://github.com/jerus-org/pcu/pull/485
 [#486]: https://github.com/jerus-org/pcu/pull/486
 [#487]: https://github.com/jerus-org/pcu/pull/487
+[#488]: https://github.com/jerus-org/pcu/pull/488
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,10 @@
 mod commit;
 mod pull_request;
+mod push;
 
 pub use commit::run_commit;
 pub use pull_request::run_pull_request;
+pub use push::run_push;
 
 use std::{env, fmt::Display, fs};
 

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -1,0 +1,39 @@
+use crate::Client;
+
+use super::{CIExit, Commands, GitOps, Push};
+
+use color_eyre::Result;
+use owo_colors::{OwoColorize, Style};
+
+pub async fn run_push(args: Push) -> Result<CIExit> {
+    let client = super::get_client(Commands::Push(args.clone())).await?;
+
+    push_committed(&client, &args.prefix, args.tag_opt(), args.no_push).await?;
+
+    if !args.no_push {
+        Ok(CIExit::Pushed(
+            "Changed files committed and pushed to remote repository.".to_string(),
+        ))
+    } else {
+        Ok(CIExit::Pushed(
+            "Changed files committed and push dry run completed for logging.".to_string(),
+        ))
+    }
+}
+
+async fn push_committed(
+    client: &Client,
+    prefix: &str,
+    tag_opt: Option<&str>,
+    no_push: bool,
+) -> Result<()> {
+    log::info!("Push the commit");
+    log::trace!("tag_opt: {tag_opt:?} and no_push: {no_push}");
+
+    client.push_commit(prefix, tag_opt, no_push)?;
+    let hdr_style = Style::new().bold().underline();
+    log::debug!("{}", "Check Push".style(hdr_style));
+    log::debug!("Branch status: {}", client.branch_status()?);
+
+    Ok(())
+}


### PR DESCRIPTION
- remove inline `run_push` function from main.rs and relocate it to a dedicated push module
- update the cli module to include `run_push` from the new push module for cleaner code organization
- improve code maintainability by separating concerns and enhancing modularity

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
