### PR TITLE
♻️ refactor(cli): centralize push command implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-modularize push command handling(pr [#488])
 - ♻️ refactor(cli)-modularize label command handling(pr [#489])
 - ♻️ refactor(cli)-modularize release logic into separate module(pr [#490])
+- ♻️ refactor(cli)-centralize push command implementation(pr [#491])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1154,6 +1155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#488]: https://github.com/jerus-org/pcu/pull/488
 [#489]: https://github.com/jerus-org/pcu/pull/489
 [#490]: https://github.com/jerus-org/pcu/pull/490
+[#491]: https://github.com/jerus-org/pcu/pull/491
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     let res = match cmd {
         Commands::Pr(pr_args) => pcu::cli::run_pull_request(sign, pr_args).await,
         Commands::Commit(commit_args) => pcu::cli::run_commit(sign, commit_args).await,
-        Commands::Push(push_args) => pcu::cli::run_push(push_args).await,
+        Commands::Push(push_args) => push_args.run_push().await,
         Commands::Label(label_args) => pcu::cli::run_label(label_args).await,
         Commands::Release(rel_args) => pcu::cli::run_release(sign, rel_args).await,
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ mod release;
 pub use commit::run_commit;
 pub use label::run_label;
 pub use pull_request::run_pull_request;
-pub use push::run_push;
+use push::Push;
 pub use release::run_release;
 
 use std::{env, fmt::Display, fs};
@@ -116,29 +116,6 @@ impl Commit {
         &self.commit_message
     }
 
-    pub fn tag_opt(&self) -> Option<&str> {
-        if let Some(semver) = &self.semver {
-            return Some(semver);
-        }
-        None
-    }
-}
-
-/// Configuration for the Push command
-#[derive(Debug, Parser, Clone)]
-pub struct Push {
-    /// Semantic version number for a tag
-    #[arg(short, long)]
-    pub semver: Option<String>,
-    /// Disable the push command
-    #[arg(short, long, default_value_t = false)]
-    pub no_push: bool,
-    /// Prefix for the version tag
-    #[clap(short, long, default_value_t = String::from("v"))]
-    pub prefix: String,
-}
-
-impl Push {
     pub fn tag_opt(&self) -> Option<&str> {
         if let Some(semver) = &self.semver {
             return Some(semver);


### PR DESCRIPTION
- move Push struct and its methods to cli/push.rs for better organization
- change run_push function to be a method of the Push struct for encapsulation

♻️ refactor(main): update push command execution

- modify main.rs to call the new run_push method on Push struct

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
