### PR TITLE
♻️ refactor(cli): move commit command logic to cli/commit.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-modularize label command handling(pr [#489])
 - ♻️ refactor(cli)-modularize release logic into separate module(pr [#490])
 - ♻️ refactor(cli)-centralize push command implementation(pr [#491])
+- ♻️ refactor(cli)-move commit command logic to cli/commit.rs(pr [#492])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1156,6 +1157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#489]: https://github.com/jerus-org/pcu/pull/489
 [#490]: https://github.com/jerus-org/pcu/pull/490
 [#491]: https://github.com/jerus-org/pcu/pull/491
+[#492]: https://github.com/jerus-org/pcu/pull/492
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     let res = match cmd {
         Commands::Pr(pr_args) => pcu::cli::run_pull_request(sign, pr_args).await,
-        Commands::Commit(commit_args) => pcu::cli::run_commit(sign, commit_args).await,
+        Commands::Commit(commit_args) => commit_args.run_commit(sign).await,
         Commands::Push(push_args) => push_args.run_push().await,
         Commands::Label(label_args) => pcu::cli::run_label(label_args).await,
         Commands::Release(rel_args) => pcu::cli::run_release(sign, rel_args).await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ mod pull_request;
 mod push;
 mod release;
 
-pub use commit::run_commit;
+use commit::Commit;
 pub use label::run_label;
 pub use pull_request::run_pull_request;
 use push::Push;
@@ -95,33 +95,6 @@ pub struct Release {
     /// Release specific workspace package
     #[clap(short = 'k', long)]
     pub package: Option<String>,
-}
-
-/// Configuration for the Commit command
-#[derive(Debug, Parser, Clone)]
-pub struct Commit {
-    /// Semantic version number for a tag
-    #[arg(short, long)]
-    pub semver: Option<String>,
-    /// Message to add to the commit when pushing
-    #[arg(short, long)]
-    commit_message: String,
-    /// Prefix for the version tag
-    #[clap(short, long, default_value_t = String::from("v"))]
-    pub prefix: String,
-}
-
-impl Commit {
-    pub fn commit_message(&self) -> &str {
-        &self.commit_message
-    }
-
-    pub fn tag_opt(&self) -> Option<&str> {
-        if let Some(semver) = &self.semver {
-            return Some(semver);
-        }
-        None
-    }
 }
 
 /// Configuration for the Rebase command


### PR DESCRIPTION
- relocate Commit struct and methods to cli/commit.rs for better organization
- update run_commit function to be a method of Commit struct
- adjust main.rs to use the new method approach for commit command

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
