### PR TITLE
♻️ refactor(cli): enhance label command structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-modularize release logic into separate module(pr [#490])
 - ♻️ refactor(cli)-centralize push command implementation(pr [#491])
 - ♻️ refactor(cli)-move commit command logic to cli/commit.rs(pr [#492])
+- ♻️ refactor(cli)-enhance label command structure(pr [#493])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1158,6 +1159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#490]: https://github.com/jerus-org/pcu/pull/490
 [#491]: https://github.com/jerus-org/pcu/pull/491
 [#492]: https://github.com/jerus-org/pcu/pull/492
+[#493]: https://github.com/jerus-org/pcu/pull/493
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         Commands::Pr(pr_args) => pcu::cli::run_pull_request(sign, pr_args).await,
         Commands::Commit(commit_args) => commit_args.run_commit(sign).await,
         Commands::Push(push_args) => push_args.run_push().await,
-        Commands::Label(label_args) => pcu::cli::run_label(label_args).await,
+        Commands::Label(label_args) => label_args.run_label().await,
         Commands::Release(rel_args) => pcu::cli::run_release(sign, rel_args).await,
     };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ mod push;
 mod release;
 
 use commit::Commit;
-pub use label::run_label;
+use label::Label;
 pub use pull_request::run_pull_request;
 use push::Push;
 pub use release::run_release;
@@ -95,53 +95,6 @@ pub struct Release {
     /// Release specific workspace package
     #[clap(short = 'k', long)]
     pub package: Option<String>,
-}
-
-/// Configuration for the Rebase command
-#[derive(Debug, Parser, Clone)]
-pub struct Label {
-    /// Override the default author login (renovate) when selecting the pull request to label
-    #[arg(short, long)]
-    pub author: Option<String>,
-    /// Override the default label (rebase) to add to the pull request
-    #[arg(short, long)]
-    pub label: Option<String>,
-    /// Override the default description for the label if it is created
-    #[arg(short, long = "description")]
-    pub desc: Option<String>,
-    /// Override the default colour (B22222) for the label if it is created
-    #[arg(short, long, visible_alias = "color")]
-    pub colour: Option<String>,
-}
-
-impl Label {
-    pub fn author(&self) -> Option<&str> {
-        if let Some(l) = &self.author {
-            return Some(l);
-        }
-        None
-    }
-
-    pub fn label(&self) -> Option<&str> {
-        if let Some(l) = &self.label {
-            return Some(l);
-        }
-        None
-    }
-
-    pub fn desc(&self) -> Option<&str> {
-        if let Some(d) = &self.desc {
-            return Some(d);
-        }
-        None
-    }
-
-    pub fn colour(&self) -> Option<&str> {
-        if let Some(c) = &self.colour {
-            return Some(c);
-        }
-        None
-    }
 }
 
 pub enum CIExit {

--- a/src/cli/label.rs
+++ b/src/cli/label.rs
@@ -1,17 +1,65 @@
-use super::{CIExit, Commands, GitOps, Label};
+use super::{CIExit, Commands, GitOps};
 
+use clap::Parser;
 use color_eyre::Result;
 
-pub async fn run_label(args: Label) -> Result<CIExit> {
-    let client = super::get_client(Commands::Label(args.clone())).await?;
+/// Configuration for the Rebase command
+#[derive(Debug, Parser, Clone)]
+pub struct Label {
+    /// Override the default author login (renovate) when selecting the pull request to label
+    #[arg(short, long)]
+    pub author: Option<String>,
+    /// Override the default label (rebase) to add to the pull request
+    #[arg(short, long)]
+    pub label: Option<String>,
+    /// Override the default description for the label if it is created
+    #[arg(short, long = "description")]
+    pub desc: Option<String>,
+    /// Override the default colour (B22222) for the label if it is created
+    #[arg(short, long, visible_alias = "color")]
+    pub colour: Option<String>,
+}
 
-    let pr_number = client
-        .label_next_pr(args.author(), args.label(), args.desc(), args.colour())
-        .await?;
+impl Label {
+    pub fn author(&self) -> Option<&str> {
+        if let Some(l) = &self.author {
+            return Some(l);
+        }
+        None
+    }
 
-    if let Some(pr_number) = pr_number {
-        Ok(CIExit::Label(pr_number))
-    } else {
-        Ok(CIExit::NoLabel)
+    pub fn label(&self) -> Option<&str> {
+        if let Some(l) = &self.label {
+            return Some(l);
+        }
+        None
+    }
+
+    pub fn desc(&self) -> Option<&str> {
+        if let Some(d) = &self.desc {
+            return Some(d);
+        }
+        None
+    }
+
+    pub fn colour(&self) -> Option<&str> {
+        if let Some(c) = &self.colour {
+            return Some(c);
+        }
+        None
+    }
+
+    pub async fn run_label(&self) -> Result<CIExit> {
+        let client = super::get_client(Commands::Label(self.clone())).await?;
+
+        let pr_number = client
+            .label_next_pr(self.author(), self.label(), self.desc(), self.colour())
+            .await?;
+
+        if let Some(pr_number) = pr_number {
+            Ok(CIExit::Label(pr_number))
+        } else {
+            Ok(CIExit::NoLabel)
+        }
     }
 }


### PR DESCRIPTION
- move Label struct implementation from cli.rs to cli/label.rs
- integrate run_label method within Label struct for better cohesion

✨ feat(cli): improve label command flexibility

- add Parser derive for Label struct to enhance command parsing
- allow optional label customization using author, label, desc, and colour fields

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
