### PR TITLE
♻️ refactor(release): restructure release command handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-centralize push command implementation(pr [#491])
 - ♻️ refactor(cli)-move commit command logic to cli/commit.rs(pr [#492])
 - ♻️ refactor(cli)-enhance label command structure(pr [#493])
+- ♻️ refactor(release)-restructure release command handling(pr [#494])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1160,6 +1161,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#491]: https://github.com/jerus-org/pcu/pull/491
 [#492]: https://github.com/jerus-org/pcu/pull/492
 [#493]: https://github.com/jerus-org/pcu/pull/493
+[#494]: https://github.com/jerus-org/pcu/pull/494
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
         Commands::Commit(commit_args) => commit_args.run_commit(sign).await,
         Commands::Push(push_args) => push_args.run_push().await,
         Commands::Label(label_args) => label_args.run_label().await,
-        Commands::Release(rel_args) => pcu::cli::run_release(sign, rel_args).await,
+        Commands::Release(rel_args) => rel_args.run_release(sign).await,
     };
 
     match res {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use commit::Commit;
 use label::Label;
 pub use pull_request::run_pull_request;
 use push::Push;
-pub use release::run_release;
+use release::Release;
 
 use std::{env, fmt::Display, fs};
 
@@ -76,25 +76,6 @@ pub struct Pr {
     /// Allow git push to fail. Allows the case of two parallel updates where the second push would fail.
     #[clap(short, long, default_value_t = false)]
     pub allow_push_fail: bool,
-}
-
-#[derive(Debug, Parser, Clone)]
-pub struct Release {
-    /// Semantic version number for the release
-    #[arg(short, long)]
-    pub semver: Option<String>,
-    /// Update the changelog by renaming the unreleased section with the version number
-    #[arg(short, long, default_value_t = false)]
-    pub update_changelog: bool,
-    /// Prefix for the version tag
-    #[clap(short, long, default_value_t = String::from("v"))]
-    pub prefix: String,
-    /// Process packages in the workspace
-    #[clap(short, long, default_value_t = false)]
-    pub workspace: bool,
-    /// Release specific workspace package
-    #[clap(short = 'k', long)]
-    pub package: Option<String>,
 }
 
 pub enum CIExit {

--- a/src/cli/release.rs
+++ b/src/cli/release.rs
@@ -2,119 +2,141 @@ use std::{fs, path::Path};
 
 use crate::{Client, GitOps, MakeRelease, Sign, Workspace};
 
-use super::{CIExit, Commands, Release};
+use super::{CIExit, Commands};
 
+use clap::Parser;
 use color_eyre::Result;
 
-pub async fn run_release(sign: Sign, args: Release) -> Result<CIExit> {
-    let client = super::get_client(Commands::Release(args.clone())).await?;
-
-    if args.workspace {
-        log::info!("Running release for workspace");
-        return release_workspace(client, args).await;
-    };
-
-    if args.package.is_some() {
-        return release_package(client, args).await;
-    }
-
-    release_semver(client, args, sign).await
+#[derive(Debug, Parser, Clone)]
+pub struct Release {
+    /// Semantic version number for the release
+    #[arg(short, long)]
+    pub semver: Option<String>,
+    /// Update the changelog by renaming the unreleased section with the version number
+    #[arg(short, long, default_value_t = false)]
+    pub update_changelog: bool,
+    /// Prefix for the version tag
+    #[clap(short, long, default_value_t = String::from("v"))]
+    pub prefix: String,
+    /// Process packages in the workspace
+    #[clap(short, long, default_value_t = false)]
+    pub workspace: bool,
+    /// Release specific workspace package
+    #[clap(short = 'k', long)]
+    pub package: Option<String>,
 }
 
-async fn release_workspace(client: Client, args: Release) -> Result<CIExit> {
-    let path = Path::new("./Cargo.toml");
-    let workspace = Workspace::new(path).unwrap();
+impl Release {
+    pub async fn run_release(self, sign: Sign) -> Result<CIExit> {
+        let client = super::get_client(Commands::Release(self.clone())).await?;
 
-    let packages = workspace.packages();
+        if self.workspace {
+            log::info!("Running release for workspace");
+            return self.release_workspace(client).await;
+        };
 
-    if let Some(packages) = packages {
-        for package in packages {
-            let prefix = format!("{}-{}", package.name, args.prefix);
-            let version = package.version;
-            let tag = format!("{prefix}{version}");
-            if !client.tag_exists(&tag) {
-                log::error!("Tag does not exist: {tag}");
-            } else {
-                log::info!("Tag already exists: {tag}, attempt to make release");
-                client.make_release(&prefix, &version).await?;
+        if self.package.is_some() {
+            return self.release_package(client).await;
+        }
+
+        self.release_semver(client, sign).await
+    }
+
+    async fn release_workspace(&self, client: Client) -> Result<CIExit> {
+        let path = Path::new("./Cargo.toml");
+        let workspace = Workspace::new(path).unwrap();
+
+        let packages = workspace.packages();
+
+        if let Some(packages) = packages {
+            for package in packages {
+                let prefix = format!("{}-{}", package.name, self.prefix);
+                let version = package.version;
+                let tag = format!("{prefix}{version}");
+                if !client.tag_exists(&tag) {
+                    log::error!("Tag does not exist: {tag}");
+                } else {
+                    log::info!("Tag already exists: {tag}, attempt to make release");
+                    client.make_release(&prefix, &version).await?;
+                }
             }
         }
+        Ok(CIExit::Released)
     }
-    Ok(CIExit::Released)
-}
 
-async fn release_package(client: Client, args: Release) -> Result<CIExit> {
-    let rel_package = args.package.unwrap();
-    log::info!("Running release for package: {}", rel_package);
+    async fn release_package(self, client: Client) -> Result<CIExit> {
+        let rel_package = self.package.unwrap();
+        log::info!("Running release for package: {}", rel_package);
 
-    let path = Path::new("./Cargo.toml");
-    let workspace = Workspace::new(path).unwrap();
+        let path = Path::new("./Cargo.toml");
+        let workspace = Workspace::new(path).unwrap();
 
-    let packages = workspace.packages();
+        let packages = workspace.packages();
 
-    if let Some(packages) = packages {
-        for package in packages {
-            log::debug!("Found workspace package: {}", package.name);
-            if package.name != rel_package {
-                continue;
+        if let Some(packages) = packages {
+            for package in packages {
+                log::debug!("Found workspace package: {}", package.name);
+                if package.name != rel_package {
+                    continue;
+                }
+                let prefix = format!("{}-{}", package.name, self.prefix);
+                let version = package.version;
+                let tag = format!("{prefix}{version}");
+                if !client.tag_exists(&tag) {
+                    log::error!("Tag does not exist: {tag}");
+                } else {
+                    log::info!("Tag already exists: {tag}, attempt to make release");
+                    client.make_release(&prefix, &version).await?;
+                }
+                break;
             }
-            let prefix = format!("{}-{}", package.name, args.prefix);
-            let version = package.version;
-            let tag = format!("{prefix}{version}");
-            if !client.tag_exists(&tag) {
-                log::error!("Tag does not exist: {tag}");
-            } else {
-                log::info!("Tag already exists: {tag}, attempt to make release");
-                client.make_release(&prefix, &version).await?;
-            }
-            break;
         }
+        Ok(CIExit::Released)
     }
-    Ok(CIExit::Released)
-}
 
-async fn release_semver(mut client: Client, args: Release, sign: Sign) -> Result<CIExit> {
-    let Some(version) = args.semver else {
-        log::error!("Semver required to update changelog");
-        return Ok(CIExit::UnChanged);
-    };
+    async fn release_semver(self, mut client: Client, sign: Sign) -> Result<CIExit> {
+        let Some(version) = self.semver else {
+            log::error!("Semver required to update changelog");
+            return Ok(CIExit::UnChanged);
+        };
 
-    log::trace!("Running release {version}");
-    log::trace!(
-        "PR ID: {} - Owner: {} - Repo: {}",
-        client.pr_number(),
-        client.owner(),
-        client.repo()
-    );
-    log::trace!("Signing: {:?}", sign);
-    log::trace!("Update changelog flag: {}", args.update_changelog);
-
-    if args.update_changelog {
-        client.release_unreleased(&version)?;
-        log::debug!("Changelog file name: {}", client.changelog_as_str());
-
+        log::trace!("Running release {version}");
         log::trace!(
-            "{}",
-            print_changelog(client.changelog_as_str(), client.line_limit())
+            "PR ID: {} - Owner: {} - Repo: {}",
+            client.pr_number(),
+            client.owner(),
+            client.repo()
         );
+        log::trace!("Signing: {:?}", sign);
+        log::trace!("Update changelog flag: {}", self.update_changelog);
 
-        let commit_message = "chore: update changelog for pr";
+        if self.update_changelog {
+            client.release_unreleased(&version)?;
+            log::debug!("Changelog file name: {}", client.changelog_as_str());
 
-        crate::cli::commit_changed_files(
-            &client,
-            sign,
-            commit_message,
-            &args.prefix,
-            Some(&version),
-        )
-        .await?;
+            log::trace!(
+                "{}",
+                print_changelog(client.changelog_as_str(), client.line_limit())
+            );
 
-        crate::cli::push_committed(&client, &args.prefix, Some(&version), false).await?;
+            let commit_message = "chore: update changelog for pr";
+
+            crate::cli::commit_changed_files(
+                &client,
+                sign,
+                commit_message,
+                &self.prefix,
+                Some(&version),
+            )
+            .await?;
+
+            crate::cli::push_committed(&client, &self.prefix, Some(&version), false).await?;
+        }
+
+        client.make_release(&self.prefix, &version).await?;
+
+        Ok(CIExit::Released)
     }
-
-    client.make_release(&args.prefix, &version).await?;
-
-    Ok(CIExit::Released)
 }
 
 fn print_changelog(changelog_path: &str, mut line_limit: usize) -> String {


### PR DESCRIPTION
- move Release struct definition to `cli/release.rs` for modularity
- implement run_release as a method of Release for consistency
- separate workspace and package release logic into distinct methods
- improve code readability and maintainability by refactoring logic

🐛 fix(release): correct release command execution

- modify run_release method call to adhere to new release structure
- ensure proper invocation of release methods within main function

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
