### PR TITLE
♻️ refactor(cli): migrate `Pr` struct and method to `pull_request.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-move commit command logic to cli/commit.rs(pr [#492])
 - ♻️ refactor(cli)-enhance label command structure(pr [#493])
 - ♻️ refactor(release)-restructure release command handling(pr [#494])
+- ♻️ refactor(cli)-migrate `Pr` struct and method to `pull_request.rs`(pr [#495])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1162,6 +1163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#492]: https://github.com/jerus-org/pcu/pull/492
 [#493]: https://github.com/jerus-org/pcu/pull/493
 [#494]: https://github.com/jerus-org/pcu/pull/494
+[#495]: https://github.com/jerus-org/pcu/pull/495
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let cmd = args.command.clone();
 
     let res = match cmd {
-        Commands::Pr(pr_args) => pcu::cli::run_pull_request(sign, pr_args).await,
+        Commands::Pr(pr_args) => pr_args.run_pull_request(sign).await,
         Commands::Commit(commit_args) => commit_args.run_commit(sign).await,
         Commands::Push(push_args) => push_args.run_push().await,
         Commands::Label(label_args) => label_args.run_label().await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ mod release;
 
 use commit::Commit;
 use label::Label;
-pub use pull_request::run_pull_request;
+use pull_request::Pr;
 use push::Push;
 use release::Release;
 
@@ -63,19 +63,6 @@ impl Display for Commands {
             Commands::Label(_) => write!(f, "label"),
         }
     }
-}
-
-#[derive(Debug, Parser, Clone)]
-pub struct Pr {
-    /// Signal an early exit as the changelog is already updated
-    #[clap(short, long, default_value_t = false)]
-    pub early_exit: bool,
-    /// Prefix for the version tag
-    #[clap(short, long, default_value_t = String::from("v"))]
-    pub prefix: String,
-    /// Allow git push to fail. Allows the case of two parallel updates where the second push would fail.
-    #[clap(short, long, default_value_t = false)]
-    pub allow_push_fail: bool,
 }
 
 pub enum CIExit {

--- a/src/cli/pull_request.rs
+++ b/src/cli/pull_request.rs
@@ -5,95 +5,111 @@ use crate::{
     Sign, UpdateFromPr,
 };
 
-use super::{CIExit, Pr};
+use super::CIExit;
 
+use clap::Parser;
 use color_eyre::Result;
 use keep_a_changelog::ChangeKind;
 
 const SIGNAL_HALT: &str = "halt";
 
-pub async fn run_pull_request(sign: Sign, args: Pr) -> Result<CIExit> {
-    let branch = env::var("CIRCLE_BRANCH");
-    let branch = branch.unwrap_or("main".to_string());
-    log::trace!("Branch: {branch:?}");
+#[derive(Debug, Parser, Clone)]
+pub struct Pr {
+    /// Signal an early exit as the changelog is already updated
+    #[clap(short, long, default_value_t = false)]
+    pub early_exit: bool,
+    /// Prefix for the version tag
+    #[clap(short, long, default_value_t = String::from("v"))]
+    pub prefix: String,
+    /// Allow git push to fail. Allows the case of two parallel updates where the second push would fail.
+    #[clap(short, long, default_value_t = false)]
+    pub allow_push_fail: bool,
+}
 
-    if branch == "main" {
-        log::info!("On the default branch, nothing to do here!");
-        if args.early_exit {
-            println!("{SIGNAL_HALT}");
-        }
+impl Pr {
+    pub async fn run_pull_request(&self, sign: Sign) -> Result<CIExit> {
+        let branch = env::var("CIRCLE_BRANCH");
+        let branch = branch.unwrap_or("main".to_string());
+        log::trace!("Branch: {branch:?}");
 
-        return Ok(CIExit::UnChanged);
-    }
-
-    log::trace!("*** Get Client ***");
-    let mut client = crate::cli::get_client(Commands::Pr(args.clone())).await?;
-
-    log::info!(
-        "On the `{}` branch, so time to get to work!",
-        client.branch_or_main()
-    );
-    log::debug!(
-        "PR ID: {} - Owner: {} - Repo: {}",
-        client.pr_number(),
-        client.owner(),
-        client.repo()
-    );
-
-    log::trace!("Full client: {:#?}", client);
-    let title = client.title();
-
-    log::debug!("Pull Request Title: {title}");
-
-    client.create_entry()?;
-
-    log::debug!("Proposed entry: {:?}", client.entry());
-
-    if log::log_enabled!(log::Level::Info) {
-        if let Some((section, entry)) = client.update_changelog()? {
-            let section = match section {
-                ChangeKind::Added => "Added",
-                ChangeKind::Changed => "Changed",
-                ChangeKind::Deprecated => "Deprecated",
-                ChangeKind::Fixed => "Fixed",
-                ChangeKind::Removed => "Removed",
-                ChangeKind::Security => "Security",
-            };
-            log::info!("Amendment: In section `{section}`, adding `{entry}`");
-        } else {
-            log::info!("No update required");
-            if args.early_exit {
+        if branch == "main" {
+            log::info!("On the default branch, nothing to do here!");
+            if self.early_exit {
                 println!("{SIGNAL_HALT}");
             }
+
             return Ok(CIExit::UnChanged);
-        };
-    } else if client.update_changelog()?.is_none() {
-        return Ok(CIExit::UnChanged);
-    }
+        }
 
-    log::debug!("Changelog file name: {}", client.changelog_as_str());
+        log::trace!("*** Get Client ***");
+        let mut client = crate::cli::get_client(Commands::Pr(self.clone())).await?;
 
-    log::trace!(
-        "{}",
-        crate::cli::print_changelog(client.changelog_as_str(), client.line_limit())
-    );
+        log::info!(
+            "On the `{}` branch, so time to get to work!",
+            client.branch_or_main()
+        );
+        log::debug!(
+            "PR ID: {} - Owner: {} - Repo: {}",
+            client.pr_number(),
+            client.owner(),
+            client.repo()
+        );
 
-    let commit_message = "chore: update changelog for pr";
+        log::trace!("Full client: {:#?}", client);
+        let title = client.title();
 
-    commit_changed_files(&client, sign, commit_message, &args.prefix, None).await?;
+        log::debug!("Pull Request Title: {title}");
 
-    let res = crate::cli::push_committed(&client, &args.prefix, None, false).await;
-    match res {
-        Ok(()) => Ok(CIExit::Updated),
-        Err(e) => {
-            if args.allow_push_fail
-                && e.to_string()
-                    .contains("cannot push non-fastforwardable reference")
-            {
-                log::info!("Cannot psh non-fastforwardable reference, presuming change made already in parallel job.");
-                Ok(CIExit::UnChanged)
+        client.create_entry()?;
+
+        log::debug!("Proposed entry: {:?}", client.entry());
+
+        if log::log_enabled!(log::Level::Info) {
+            if let Some((section, entry)) = client.update_changelog()? {
+                let section = match section {
+                    ChangeKind::Added => "Added",
+                    ChangeKind::Changed => "Changed",
+                    ChangeKind::Deprecated => "Deprecated",
+                    ChangeKind::Fixed => "Fixed",
+                    ChangeKind::Removed => "Removed",
+                    ChangeKind::Security => "Security",
+                };
+                log::info!("Amendment: In section `{section}`, adding `{entry}`");
             } else {
-                Err(e)
+                log::info!("No update required");
+                if self.early_exit {
+                    println!("{SIGNAL_HALT}");
+                }
+                return Ok(CIExit::UnChanged);
+            };
+        } else if client.update_changelog()?.is_none() {
+            return Ok(CIExit::UnChanged);
+        }
+
+        log::debug!("Changelog file name: {}", client.changelog_as_str());
+
+        log::trace!(
+            "{}",
+            crate::cli::print_changelog(client.changelog_as_str(), client.line_limit())
+        );
+
+        let commit_message = "chore: update changelog for pr";
+
+        commit_changed_files(&client, sign, commit_message, &self.prefix, None).await?;
+
+        let res = crate::cli::push_committed(&client, &self.prefix, None, false).await;
+        match res {
+            Ok(()) => Ok(CIExit::Updated),
+            Err(e) => {
+                if self.allow_push_fail
+                    && e.to_string()
+                        .contains("cannot push non-fastforwardable reference")
+                {
+                    log::info!("Cannot psh non-fastforwardable reference, presuming change made already in parallel job.");
+                    Ok(CIExit::UnChanged)
+                } else {
+                    Err(e)
+                }
             }
         }
     }


### PR DESCRIPTION
- move `Pr` struct definition from `cli.rs` to `pull_request.rs`
- integrate `run_pull_request` method into `Pr` struct for better encapsulation

♻️ refactor(main): update pull request command to use method on `Pr`

- change invocation of pull request command to use the method on the `Pr` struct

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
