### PR TITLE
♻️ refactor(cli): remove duplicate commit function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cli)-migrate `Pr` struct and method to `pull_request.rs`(pr [#495])
 - ♻️ refactor(cli)-refactor client acquisition method(pr [#496])
 - ♻️ refactor(cli)-remove duplicate push_committed function(pr [#497])
+- ♻️ refactor(cli)-remove duplicate commit function(pr [#498])
 
 ## [0.4.33] - 2025-03-01
 
@@ -1168,6 +1169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#495]: https://github.com/jerus-org/pcu/pull/495
 [#496]: https://github.com/jerus-org/pcu/pull/496
 [#497]: https://github.com/jerus-org/pcu/pull/497
+[#498]: https://github.com/jerus-org/pcu/pull/498
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.33...HEAD
 [0.4.33]: https://github.com/jerus-org/pcu/compare/v0.4.32...v0.4.33
 [0.4.32]: https://github.com/jerus-org/pcu/compare/v0.4.31...v0.4.32

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,6 @@ use std::{env, fmt::Display, fs};
 use clap::{Parser, Subcommand};
 use color_eyre::Result;
 use config::Config;
-use owo_colors::{OwoColorize, Style};
 
 use crate::{Client, Error, GitOps, Sign};
 
@@ -155,47 +154,4 @@ fn print_changelog(changelog_path: &str, mut line_limit: usize) -> String {
     };
 
     output
-}
-
-async fn commit_changed_files(
-    client: &Client,
-    sign: Sign,
-    commit_message: &str,
-    prefix: &str,
-    tag_opt: Option<&str>,
-) -> Result<()> {
-    let hdr_style = Style::new().bold().underline();
-    log::debug!("{}", "Check WorkDir".style(hdr_style));
-
-    let files_in_workdir = client.repo_files_not_staged()?;
-
-    log::debug!("WorkDir files:\n\t{:?}", files_in_workdir);
-    log::debug!("Staged files:\n\t{:?}", client.repo_files_staged()?);
-    log::debug!("Branch status: {}", client.branch_status()?);
-
-    log::info!("Stage the changes for commit");
-
-    client.stage_files(files_in_workdir)?;
-
-    log::debug!("{}", "Check Staged".style(hdr_style));
-    log::debug!("WorkDir files:\n\t{:?}", client.repo_files_not_staged()?);
-
-    let files_staged_for_commit = client.repo_files_staged()?;
-
-    log::debug!("Staged files:\n\t{:?}", files_staged_for_commit);
-    log::debug!("Branch status: {}", client.branch_status()?);
-
-    log::info!("Commit the staged changes");
-
-    client.commit_staged(sign, commit_message, prefix, tag_opt)?;
-
-    log::debug!("{}", "Check Committed".style(hdr_style));
-    log::debug!("WorkDir files:\n\t{:?}", client.repo_files_not_staged()?);
-
-    let files_staged_for_commit = client.repo_files_staged()?;
-
-    log::debug!("Staged files:\n\t{:?}", files_staged_for_commit);
-    log::debug!("Branch status: {}", client.branch_status()?);
-
-    Ok(())
 }

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -3,7 +3,7 @@ use crate::Sign;
 use clap::Parser;
 use color_eyre::Result;
 
-use super::{CIExit, Commands};
+use super::{CIExit, Commands, GitOps};
 
 /// Configuration for the Commit command
 #[derive(Debug, Parser, Clone)]
@@ -34,14 +34,9 @@ impl Commit {
     pub async fn run_commit(&self, sign: Sign) -> Result<CIExit> {
         let client = Commands::Commit(self.clone()).get_client().await?;
 
-        super::commit_changed_files(
-            &client,
-            sign,
-            self.commit_message(),
-            &self.prefix,
-            self.tag_opt(),
-        )
-        .await?;
+        client
+            .commit_changed_files(sign, self.commit_message(), &self.prefix, self.tag_opt())
+            .await?;
 
         Ok(CIExit::Committed)
     }

--- a/src/cli/pull_request.rs
+++ b/src/cli/pull_request.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use crate::{
-    cli::{commit_changed_files, Commands, GitOps},
+    cli::{Commands, GitOps},
     Sign, UpdateFromPr,
 };
 
@@ -96,7 +96,9 @@ impl Pr {
 
         let commit_message = "chore: update changelog for pr";
 
-        commit_changed_files(&client, sign, commit_message, &self.prefix, None).await?;
+        client
+            .commit_changed_files(sign, commit_message, &self.prefix, None)
+            .await?;
 
         log::info!("Push the commit");
         log::trace!("tag_opt: None and no_push: false");

--- a/src/cli/release.rs
+++ b/src/cli/release.rs
@@ -122,14 +122,9 @@ impl Release {
 
             let commit_message = "chore: update changelog for pr";
 
-            crate::cli::commit_changed_files(
-                &client,
-                sign,
-                commit_message,
-                &self.prefix,
-                Some(&version),
-            )
-            .await?;
+            client
+                .commit_changed_files(sign, commit_message, &self.prefix, Some(&version))
+                .await?;
 
             log::info!("Push the commit");
             log::trace!("tag_opt: {:?} and no_push: {:?}", Some(&version), false);

--- a/src/ops/git_ops.rs
+++ b/src/ops/git_ops.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use clap::ValueEnum;
-use color_eyre::owo_colors::OwoColorize;
 use git2::{
     BranchType, Cred, Direction, Oid, PushOptions, RemoteCallbacks, Signature, StatusOptions,
 };
 use log::log_enabled;
 use octocrate::repos::list_tags::Query;
+use owo_colors::{OwoColorize, Style};
 use tracing::instrument;
 
 use crate::client::graphql::GraphQLGetOpenPRs;
@@ -36,6 +36,14 @@ pub trait GitOps {
     fn repo_files_not_staged(&self) -> Result<Vec<String>, Error>;
     fn repo_files_staged(&self) -> Result<Vec<String>, Error>;
     fn stage_files(&self, files: Vec<String>) -> Result<(), Error>;
+    #[allow(async_fn_in_trait)]
+    async fn commit_changed_files(
+        &self,
+        sign: Sign,
+        commit_message: &str,
+        prefix: &str,
+        tag_opt: Option<&str>,
+    ) -> Result<(), Error>;
     fn commit_staged(
         &self,
         sign: Sign,
@@ -183,6 +191,49 @@ impl GitOps for Client {
         }
 
         index.write()?;
+
+        Ok(())
+    }
+
+    async fn commit_changed_files(
+        &self,
+        sign: Sign,
+        commit_message: &str,
+        prefix: &str,
+        tag_opt: Option<&str>,
+    ) -> Result<(), Error> {
+        let hdr_style = Style::new().bold().underline();
+        log::debug!("{}", "Check WorkDir".style(hdr_style));
+
+        let files_in_workdir = self.repo_files_not_staged()?;
+
+        log::debug!("WorkDir files:\n\t{:?}", files_in_workdir);
+        log::debug!("Staged files:\n\t{:?}", self.repo_files_staged()?);
+        log::debug!("Branch status: {}", self.branch_status()?);
+
+        log::info!("Stage the changes for commit");
+
+        self.stage_files(files_in_workdir)?;
+
+        log::debug!("{}", "Check Staged".style(hdr_style));
+        log::debug!("WorkDir files:\n\t{:?}", self.repo_files_not_staged()?);
+
+        let files_staged_for_commit = self.repo_files_staged()?;
+
+        log::debug!("Staged files:\n\t{:?}", files_staged_for_commit);
+        log::debug!("Branch status: {}", self.branch_status()?);
+
+        log::info!("Commit the staged changes");
+
+        self.commit_staged(sign, commit_message, prefix, tag_opt)?;
+
+        log::debug!("{}", "Check Committed".style(hdr_style));
+        log::debug!("WorkDir files:\n\t{:?}", self.repo_files_not_staged()?);
+
+        let files_staged_for_commit = self.repo_files_staged()?;
+
+        log::debug!("Staged files:\n\t{:?}", files_staged_for_commit);
+        log::debug!("Branch status: {}", self.branch_status()?);
 
         Ok(())
     }


### PR DESCRIPTION
- remove `commit_changed_files` function from cli module
- utilize GitOps trait for commit operations

🐛 fix(git_ops): add commit function to GitOps trait

- implement `commit_changed_files` function in GitOps trait
- ensure consistent commit handling across modules

🔧 chore(dependencies): adjust import paths for owo_colors

- move owo_colors imports from cli to git_ops module

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
