### PR TITLE
✨ feat(cli): add storage directory option for Bluesky posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ add storage directory option for Bluesky posts(pr [#512])
+
 ### Changed
 
 - 👷 ci(circleci)-update toolkit orb and streamline config(pr [#510])
@@ -1213,6 +1217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#509]: https://github.com/jerus-org/pcu/pull/509
 [#510]: https://github.com/jerus-org/pcu/pull/510
 [#511]: https://github.com/jerus-org/pcu/pull/511
+[#512]: https://github.com/jerus-org/pcu/pull/512
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.35...HEAD
 [0.4.35]: https://github.com/jerus-org/pcu/compare/v0.4.34...v0.4.35
 [0.4.34]: https://github.com/jerus-org/pcu/compare/v0.4.33...v0.4.34

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,7 +125,7 @@ impl Commands {
             Commands::Bsky(bsky) => settings
                 .set_override("commit_message", "chore: add Bluesky posts to repository")?
                 .set_override("store", bsky.store.clone())?
-                .set_override("command", "bsky")?
+                .set_override("command", "bsky")?,
         };
 
         settings = if let Commands::Bsky(bsky) = self {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,7 +122,10 @@ impl Commands {
             Commands::Label(_) => settings
                 .set_override("commit_message", "chore: update changelog for release")?
                 .set_override("command", "label")?,
-            Commands::Bsky(_) => settings.set_override("command", "bsky")?,
+            Commands::Bsky(bsky) => settings
+                .set_override("commit_message", "chore: add Bluesky posts to repository")?
+                .set_override("store", bsky.store.clone())?
+                .set_override("command", "bsky")?
         };
 
         settings = if let Commands::Bsky(bsky) = self {

--- a/src/cli/bsky.rs
+++ b/src/cli/bsky.rs
@@ -33,6 +33,9 @@ pub struct Bsky {
     /// file with application private key for access to the repository
     #[arg(short, long)]
     pub pk: Option<String>,
+    /// directory to store the Bluesky posts
+    #[arg(short, long, default_value_t = BSKY_POSTS_DIR.to_string())]
+    pub store: String,
     /// Command to execute
     #[command(subcommand)]
     pub cmd: Cmd,

--- a/src/cli/bsky/commands/cmd_draft.rs
+++ b/src/cli/bsky/commands/cmd_draft.rs
@@ -79,6 +79,7 @@ impl CmdDraft {
             .add_posts(&mut front_matters)?
             .process_posts()
             .await?
+            .add_store(&settings.get_string("store")?)?
             .write_posts()?;
 
         let sign = Sign::Gpg;

--- a/src/cli/bsky/commands/cmd_draft/draft.rs
+++ b/src/cli/bsky/commands/cmd_draft/draft.rs
@@ -11,7 +11,6 @@ use bsky_sdk::{
 pub use front_matter::FrontMatter;
 use site_config::SiteConfig;
 
-use super::super::super::BSKY_POSTS_DIR;
 use crate::Error;
 
 #[derive(Clone, Default)]
@@ -19,6 +18,7 @@ pub struct Draft {
     blog_posts: Vec<FrontMatter>,
     base_url: String,
     path: String,
+    store: String,
 }
 impl Draft {
     // pub fn new() -> Result<Self, Error> {
@@ -129,7 +129,17 @@ impl Draft {
         Ok(self)
     }
 
+    pub fn add_store(&mut self, store: &str) -> Result<&mut Self, Error> {
+        self.store = store.to_string();
+        Ok(self)
+    }
     pub fn write_posts(&self) -> Result<(), Error> {
+        // create store directory if it doesn't exist
+        if !std::path::Path::new(&self.store).exists() {
+            std::fs::create_dir_all(self.store.clone())?;
+        }
+
+
         for blog_post in &self.blog_posts {
             let Some(bluesky_post) = &blog_post.bluesky_post else {
                 log::warn!("No Bluesky post found for blog post: {}", blog_post.title);
@@ -146,7 +156,7 @@ impl Draft {
 
             let post_file = format!(
                 "{}/{}.post",
-                BSKY_POSTS_DIR,
+                self.store,
                 filename.trim_end_matches(".md")
             );
             log::debug!("Post file: {}", post_file);

--- a/src/cli/bsky/commands/cmd_draft/draft.rs
+++ b/src/cli/bsky/commands/cmd_draft/draft.rs
@@ -139,7 +139,6 @@ impl Draft {
             std::fs::create_dir_all(self.store.clone())?;
         }
 
-
         for blog_post in &self.blog_posts {
             let Some(bluesky_post) = &blog_post.bluesky_post else {
                 log::warn!("No Bluesky post found for blog post: {}", blog_post.title);
@@ -154,11 +153,7 @@ impl Draft {
             log::trace!("Bluesky post: {bluesky_post:#?}");
             log::debug!("Post filename: {}", filename);
 
-            let post_file = format!(
-                "{}/{}.post",
-                self.store,
-                filename.trim_end_matches(".md")
-            );
+            let post_file = format!("{}/{}.post", self.store, filename.trim_end_matches(".md"));
             log::debug!("Post file: {}", post_file);
 
             let file = File::create(post_file)?;

--- a/src/cli/bsky/commands/cmd_post.rs
+++ b/src/cli/bsky/commands/cmd_post.rs
@@ -14,10 +14,7 @@ impl CmdPost {
         let id = settings.get::<String>("bsky_id")?;
         let pw = settings.get::<String>("bsky_password")?;
         let store = settings.get::<String>("store")?;
-        Poster::new()?
-            .load(store)?
-            .post_to_bluesky(id, pw)
-            .await?;
+        Poster::new()?.load(store)?.post_to_bluesky(id, pw).await?;
 
         // Commit to remove the posts successfully sent to Bluesky
         let sign = Sign::Gpg;

--- a/src/cli/bsky/commands/cmd_post.rs
+++ b/src/cli/bsky/commands/cmd_post.rs
@@ -6,8 +6,6 @@ use poster::Poster;
 
 use crate::{CIExit, Client, Error, GitOps, Sign};
 
-use super::super::BSKY_POSTS_DIR;
-
 #[derive(Debug, Parser, Clone)]
 pub struct CmdPost;
 
@@ -15,8 +13,9 @@ impl CmdPost {
     pub async fn run(&self, client: &Client, settings: &Config) -> Result<CIExit, Error> {
         let id = settings.get::<String>("bsky_id")?;
         let pw = settings.get::<String>("bsky_password")?;
+        let store = settings.get::<String>("store")?;
         Poster::new()?
-            .load(BSKY_POSTS_DIR)?
+            .load(store)?
             .post_to_bluesky(id, pw)
             .await?;
 


### PR DESCRIPTION
- add 'store' argument to specify directory for storing Bluesky posts
- set default storage directory to 'BSKY_POSTS_DIR' for convenience

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
