### PR TITLE
✨ feat(cli): add fail_on_missing option to CmdPost

### DIFF
--- a/src/cli/bsky/commands/cmd_post.rs
+++ b/src/cli/bsky/commands/cmd_post.rs
@@ -7,14 +7,30 @@ use poster::Poster;
 use crate::{CIExit, Client, Error, GitOps, Sign};
 
 #[derive(Debug, Parser, Clone)]
-pub struct CmdPost;
+pub struct CmdPost {
+    /// Fail if the files to process are missing
+    #[arg(short, long)]
+    pub fail_on_missing: bool,
+}
 
 impl CmdPost {
     pub async fn run(&self, client: &Client, settings: &Config) -> Result<CIExit, Error> {
         let id = settings.get::<String>("bsky_id")?;
         let pw = settings.get::<String>("bsky_password")?;
         let store = settings.get::<String>("store")?;
-        Poster::new()?.load(store)?.post_to_bluesky(id, pw).await?;
+        let mut poster = Poster::new()?;
+        match poster.load(store) {
+            Ok(_) => {}
+            Err(e) => {
+                if self.fail_on_missing {
+                    return Err(e);
+                } else {
+                    log::warn!("{}", e);
+                    return Ok(CIExit::NoFilesToProcess);
+                }
+            }
+        };
+        poster.post_to_bluesky(id, pw).await?;
 
         // Commit to remove the posts successfully sent to Bluesky
         let sign = Sign::Gpg;


### PR DESCRIPTION
- introduce fail_on_missing flag to handle missing files scenario
- log warning instead of error when files are missing without flag

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
