### PR TITLE
✨ feat(cli): add bot user name for push_commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ✨ add fail_on_missing option to CmdPost(pr [#530])
+- ✨ add bot user name for push_commit(pr [#531])
 
 ### Changed
 
@@ -1279,6 +1280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#528]: https://github.com/jerus-org/pcu/pull/528
 [#529]: https://github.com/jerus-org/pcu/pull/529
 [#530]: https://github.com/jerus-org/pcu/pull/530
+[#531]: https://github.com/jerus-org/pcu/pull/531
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.39...HEAD
 [0.4.39]: https://github.com/jerus-org/pcu/compare/v0.4.38...v0.4.39
 [0.4.38]: https://github.com/jerus-org/pcu/compare/v0.4.37...v0.4.38

--- a/src/cli/pull_request.rs
+++ b/src/cli/pull_request.rs
@@ -118,7 +118,10 @@ impl Pr {
         }
         log::trace!("tag_opt: None and no_push: false");
 
-        let res = client.push_commit(&self.prefix, None, false);
+        let bot_user_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+        log::debug!("Using bot user name: {}", bot_user_name);
+
+        let res = client.push_commit(&self.prefix, None, false, &bot_user_name);
         let hdr_style = Style::new().bold().underline();
         log::debug!("{}", "Check Push".style(hdr_style));
         log::debug!("Branch status: {}", client.branch_status()?);

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -37,7 +37,10 @@ impl Push {
             self.no_push
         );
 
-        client.push_commit(&self.prefix, self.tag_opt(), self.no_push)?;
+        let bot_user_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+        log::debug!("Using bot user name: {}", bot_user_name);
+
+        client.push_commit(&self.prefix, self.tag_opt(), self.no_push, &bot_user_name)?;
         let hdr_style = Style::new().bold().underline();
         log::debug!("{}", "Check Push".style(hdr_style));
         log::debug!("Branch status: {}", client.branch_status()?);

--- a/src/cli/release.rs
+++ b/src/cli/release.rs
@@ -128,7 +128,11 @@ impl Release {
             log::info!("Push the commit");
             log::trace!("tag_opt: {:?} and no_push: {:?}", Some(&version), false);
 
-            client.push_commit(&self.prefix, Some(&version), false)?;
+            let bot_user_name =
+                std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+            log::debug!("Using bot user name: {}", bot_user_name);
+
+            client.push_commit(&self.prefix, Some(&version), false, &bot_user_name)?;
             let hdr_style = Style::new().bold().underline();
             log::debug!("{}", "Check Push".style(hdr_style));
             log::debug!("Branch status: {}", client.branch_status()?);


### PR DESCRIPTION
- introduce bot user name environment variable for push_commit
- enhance logging to debug bot user name being used
- modify function signature to accept bot user name parameter across cli modules and git operations

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
