### PR TITLE
♻️ refactor(cli): simplify release mode handling

### DIFF
--- a/src/cli/release/mode.rs
+++ b/src/cli/release/mode.rs
@@ -1,69 +1,86 @@
-use std::str::FromStr;
+// use std::str::FromStr;
 
-use clap::Subcommand;
+use clap::{Parser, Subcommand};
 
-#[derive(Debug, Default, Subcommand, Clone)]
+#[derive(Debug, Parser, Clone)]
+pub struct Version {
+    /// Specific package to release
+    pub version: String,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct Package {
+    /// Specific package to release
+    pub package: String,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct Current {
+    /// Specific package to release
+    pub package: Option<String>,
+}
+
+#[derive(Debug, Subcommand, Clone)]
 pub enum Mode {
-    #[default]
-    Version,
-    Package,
+    Version(Version),
+    Package(Package),
     Workspace,
-    Current,
+    Current(Current),
 }
 
-impl FromStr for Mode {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "version" => Ok(Mode::Version),
-            "package" => Ok(Mode::Package),
-            "workspace" => Ok(Mode::Workspace),
-            "current" => Ok(Mode::Current),
-            _ => Err(format!("Invalid release path: {s}")),
-        }
-    }
-}
+// impl FromStr for Mode {
+//     type Err = String;
+//     fn from_str(s: &str) -> Result<Self, Self::Err> {
+//         match s {
+//             "version" => Ok(Mode::Version),
+//             "package" => Ok(Mode::Package(Package::from_str(s)?)),
+//             "workspace" => Ok(Mode::Workspace),
+//             "current" => Ok(Mode::Current),
+//             _ => Err(format!("Invalid release path: {s}")),
+//         }
+//     }
+// }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    #[test]
-    fn test_mode_from_str_version() {
-        assert!(matches!(Mode::from_str("version"), Ok(Mode::Version)));
-    }
+//     #[test]
+//     fn test_mode_from_str_version() {
+//         assert!(matches!(Mode::from_str("version"), Ok(Mode::Version)));
+//     }
 
-    #[test]
-    fn test_mode_from_str_package() {
-        assert!(matches!(Mode::from_str("package"), Ok(Mode::Package)));
-    }
+//     #[test]
+//     fn test_mode_from_str_package() {
+//         assert!(matches!(Mode::from_str("package"), Ok(Mode::Package)));
+//     }
 
-    #[test]
-    fn test_mode_from_str_workspace() {
-        assert!(matches!(Mode::from_str("workspace"), Ok(Mode::Workspace)));
-    }
+//     #[test]
+//     fn test_mode_from_str_workspace() {
+//         assert!(matches!(Mode::from_str("workspace"), Ok(Mode::Workspace)));
+//     }
 
-    #[test]
-    fn test_mode_from_str_current() {
-        assert!(matches!(Mode::from_str("current"), Ok(Mode::Current)));
-    }
+//     #[test]
+//     fn test_mode_from_str_current() {
+//         assert!(matches!(Mode::from_str("current"), Ok(Mode::Current)));
+//     }
 
-    #[test]
-    fn test_mode_from_str_invalid() {
-        let result = Mode::from_str("invalid");
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Invalid release path: invalid");
-    }
+//     #[test]
+//     fn test_mode_from_str_invalid() {
+//         let result = Mode::from_str("invalid");
+//         assert!(result.is_err());
+//         assert_eq!(result.unwrap_err(), "Invalid release path: invalid");
+//     }
 
-    #[test]
-    fn test_mode_from_str_empty() {
-        let result = Mode::from_str("");
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Invalid release path: ");
-    }
+//     #[test]
+//     fn test_mode_from_str_empty() {
+//         let result = Mode::from_str("");
+//         assert!(result.is_err());
+//         assert_eq!(result.unwrap_err(), "Invalid release path: ");
+//     }
 
-    #[test]
-    fn test_mode_default() {
-        assert!(matches!(Mode::default(), Mode::Version));
-    }
-}
+//     #[test]
+//     fn test_mode_default() {
+//         assert!(matches!(Mode::default(), Mode::Version));
+//     }
+// }


### PR DESCRIPTION
- remove unused semantic version and package fields from Release struct
- refactor Mode enum to use specific structs for each mode variant
- simplify release_package and release_current methods by using mode-specific structures

🔧 chore(cli): comment out unused test code in release mode

- comment out FromStr implementation and associated tests for Mode enum

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
