### PR TITLE
🐛 fix(cli): correct error handling for pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(ci)-update release.yml configuration(pr [#575])
 - 📝 docs(CHANGELOG)-update changelog for unreleased changes(pr [#576])
 
+### Fixed
+
+- 🐛 cli: correct error handling for pull request(pr [#577])
+
 ## [0.4.45] - 2025-06-28
 
 ### Added
@@ -1418,6 +1422,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#574]: https://github.com/jerus-org/pcu/pull/574
 [#575]: https://github.com/jerus-org/pcu/pull/575
 [#576]: https://github.com/jerus-org/pcu/pull/576
+[#577]: https://github.com/jerus-org/pcu/pull/577
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.45...HEAD
 [0.4.45]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.45
 [0.4.45]: https://github.com/jerus-org/pcu/compare/v0.4.44...v0.4.45

--- a/src/cli/pull_request.rs
+++ b/src/cli/pull_request.rs
@@ -52,7 +52,7 @@ impl Pr {
             Ok(client) => client,
             Err(e) => {
                 match e {
-                    Error::EnvVarPullRequestNotFound => {
+                    Error::EnvVarPullRequestNotSet => {
                         if self.allow_no_pull_request {
                             return Ok(CIExit::UnChanged);
                         } else {


### PR DESCRIPTION
- change error variant from EnvVarPullRequestNotFound to EnvVarPullRequestNotSet
- improve clarity in error messaging for unset pull request environment variable

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
