### PR TITLE
🔧 chore(config): add host rules for circleci in renovate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 🔧 chore(config)-add host rules for circleci in renovate(pr [#580])
+
 ## [0.4.49] - 2025-07-10
 
 ### Changed
@@ -1435,6 +1441,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#577]: https://github.com/jerus-org/pcu/pull/577
 [#578]: https://github.com/jerus-org/pcu/pull/578
 [#579]: https://github.com/jerus-org/pcu/pull/579
+[#580]: https://github.com/jerus-org/pcu/pull/580
+[Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.49...HEAD
 [0.4.49]: https://github.com/jerus-org/pcu/compare/v0.4.48...v0.4.49
 [0.4.48]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.48
 [0.4.45]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.45

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
   "schedule": [
     "* 0-5 24 * *"
   ],
+  "hostRules": [
+    {
+      "matchHost": "circleci.com",
+      "authType": "Token-Only"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
- include host rules with token-only auth type for circleci
- enhance automation configuration to support circleci operations

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
