### PR TITLE
🔧 chore(config): update renovate configuration path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(config)-add host rules for circleci in renovate(pr [#580])
 - 🔧 chore(config)-update renovate configuration to inherit settings(pr [#581])
 - 🔧 chore(renovate)-update configuration to extend from remote(pr [#582])
+- 🔧 chore(config)-update renovate configuration path(pr [#584])
 
 ## [0.4.49] - 2025-07-10
 
@@ -1446,6 +1447,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#580]: https://github.com/jerus-org/pcu/pull/580
 [#581]: https://github.com/jerus-org/pcu/pull/581
 [#582]: https://github.com/jerus-org/pcu/pull/582
+[#584]: https://github.com/jerus-org/pcu/pull/584
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.49...HEAD
 [0.4.49]: https://github.com/jerus-org/pcu/compare/v0.4.48...v0.4.49
 [0.4.48]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.48

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,6 @@
     "* 0-5 24 * *"
   ],
   "extends": [
-    "github>jerusdp/renovate-config/default.json"
+    "github>jerusdp/renovate-config:default.json"
   ]
 }


### PR DESCRIPTION
- change renovate extends path to use colon separator for correct config reference

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#583
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
