### PR TITLE
🐛 fix(front_matter): correct method call for tag retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deps: update rust crate uuid to 1.17.0(pr [#611])
 - 🐛 front_matter: correct short link formatting(pr [#613])
 - 🐛 front_matter: correct error handling for post length(pr [#617])
+- 🐛 front_matter: correct method call for tag retrieval(pr [#618])
 
 ## [0.4.49] - 2025-07-10
 
@@ -1519,6 +1520,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#615]: https://github.com/jerus-org/pcu/pull/615
 [#616]: https://github.com/jerus-org/pcu/pull/616
 [#617]: https://github.com/jerus-org/pcu/pull/617
+[#618]: https://github.com/jerus-org/pcu/pull/618
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.49...HEAD
 [0.4.49]: https://github.com/jerus-org/pcu/compare/v0.4.48...v0.4.49
 [0.4.48]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.48

--- a/src/cli/bsky/commands/cmd_draft/draft/front_matter.rs
+++ b/src/cli/bsky/commands/cmd_draft/draft/front_matter.rs
@@ -79,7 +79,7 @@ impl FrontMatter {
 
     fn bluesky_tags(&self) -> Vec<String> {
         if self.bluesky.is_some() {
-            return self.bluesky.as_ref().unwrap().tags();
+            return self.bluesky.as_ref().unwrap().hashtags();
         }
 
         if self.extra.is_some() && self.extra.as_ref().unwrap().bluesky.is_some() {
@@ -90,11 +90,11 @@ impl FrontMatter {
                 .bluesky
                 .as_ref()
                 .unwrap()
-                .tags();
+                .hashtags();
         }
 
         if self.taxonomies.is_some() {
-            return self.taxonomies.as_ref().unwrap().tags();
+            return self.taxonomies.as_ref().unwrap().hashtags();
         }
 
         Vec::new()

--- a/src/cli/bsky/commands/cmd_draft/draft/front_matter/bluesky.rs
+++ b/src/cli/bsky/commands/cmd_draft/draft/front_matter/bluesky.rs
@@ -11,7 +11,32 @@ impl Bluesky {
         self.description.as_deref().unwrap_or("")
     }
 
-    pub fn tags(&self) -> Vec<String> {
+    fn tags(&self) -> Vec<String> {
         self.tags.clone().unwrap_or_default()
+    }
+
+    pub fn hashtags(&self) -> Vec<String> {
+        let mut hashtags = vec![];
+        for tag in &self.tags() {
+            // convert tag to hashtag by capitalising the first letter of each word, removing the spaces and prefixing with a # if required
+            let formatted_tag = tag
+                .split_whitespace()
+                .map(|word| {
+                    let mut chars = word.chars();
+                    match chars.next() {
+                        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                        None => String::new(),
+                    }
+                })
+                .collect::<String>();
+            let hashtag = if formatted_tag.starts_with('#') {
+                formatted_tag
+            } else {
+                format!("#{formatted_tag}")
+            };
+            hashtags.push(hashtag);
+        }
+
+        hashtags
     }
 }

--- a/src/cli/bsky/commands/cmd_draft/draft/front_matter/taxonomies.rs
+++ b/src/cli/bsky/commands/cmd_draft/draft/front_matter/taxonomies.rs
@@ -11,10 +11,9 @@ impl Taxonomies {
         self.tags.clone()
     }
 
-    #[allow(dead_code)]
     pub fn hashtags(&self) -> Vec<String> {
         let mut hashtags = vec![];
-        for tag in &self.tags {
+        for tag in &self.tags() {
             // convert tag to hashtag by capitalising the first letter of each word, removing the spaces and prefixing with a # if required
             let formatted_tag = tag
                 .split_whitespace()


### PR DESCRIPTION
- remove #[allow(dead_code)] attribute
- use self.tags() method directly in loop for consistency

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
