### PR TITLE
🐛 fix(cli): correct basehead format in draft command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🐛 front_matter: correct short link formatting(pr [#613])
 - 🐛 front_matter: correct error handling for post length(pr [#617])
 - 🐛 front_matter: correct method call for tag retrieval(pr [#618])
+- 🐛 cli: correct basehead format in draft command(pr [#619])
 
 ## [0.4.49] - 2025-07-10
 
@@ -1521,6 +1522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#616]: https://github.com/jerus-org/pcu/pull/616
 [#617]: https://github.com/jerus-org/pcu/pull/617
 [#618]: https://github.com/jerus-org/pcu/pull/618
+[#619]: https://github.com/jerus-org/pcu/pull/619
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.49...HEAD
 [0.4.49]: https://github.com/jerus-org/pcu/compare/v0.4.48...v0.4.49
 [0.4.48]: https://github.com/jerus-org/pcu/compare/v0.4.45...v0.4.48

--- a/src/cli/bsky/commands/cmd_draft.rs
+++ b/src/cli/bsky/commands/cmd_draft.rs
@@ -185,7 +185,7 @@ impl CmdDraft {
             .get("branch")
             .map_err(|_| Error::EnvVarBranchNotSet)?;
         let branch = env::var(pcu_branch).map_err(|_| Error::EnvVarBranchNotFound)?;
-        let basehead = format!("main...{branch}");
+        let basehead = format!("main..{branch}");
 
         log::info!("Basehead: {basehead}");
 
@@ -195,7 +195,7 @@ impl CmdDraft {
             .compare_commits(client.owner(), client.repo(), &basehead)
             .send()
             .await?;
-
+        log::trace!("Commit comparison: {compare:?}");
         let mut changed_files = Vec::new();
         let Some(files) = compare.files else {
             log::warn!("No files found in compare");


### PR DESCRIPTION
- change triple dots to double dots in basehead to fix commit comparison
- add trace log for commit comparison details

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
