### PR TITLE
🐛 fix(git_ops): handle empty file lists during staging and committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cmd_draft)-rename methods and variables for clarity(pr [#621])
 - 💄 style(cmd_draft)-update log level for front matter(pr [#622])
 
+### Fixed
+
+- 🐛 git_ops: handle empty file lists during staging and committing(pr [#624])
+
 ## [0.4.50] - 2025-07-28
 
 ### Added
@@ -1539,6 +1543,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#621]: https://github.com/jerus-org/pcu/pull/621
 [#622]: https://github.com/jerus-org/pcu/pull/622
 [#623]: https://github.com/jerus-org/pcu/pull/623
+[#624]: https://github.com/jerus-org/pcu/pull/624
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.50...HEAD
 [0.4.50]: https://github.com/jerus-org/pcu/compare/v0.4.49...v0.4.50
 [0.4.49]: https://github.com/jerus-org/pcu/compare/v0.4.48...v0.4.49

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -41,7 +41,10 @@ impl Push {
     pub async fn run_push(&self) -> Result<CIExit, Error> {
         let client = Commands::Push(self.clone()).get_client().await?;
 
-        if client.branch_status()?.ahead == 0 {
+        let branch_status = client.branch_status()?;
+        log::debug!("Branch status report: {branch_status}");
+
+        if branch_status.ahead == 0 {
             return Ok(CIExit::NothingToPush);
         };
 

--- a/src/ops/git_ops.rs
+++ b/src/ops/git_ops.rs
@@ -285,7 +285,9 @@ impl GitOps for Client {
 
         log::info!("Stage the changes for commit");
 
-        self.stage_files(files_in_workdir)?;
+        if !files_in_workdir.is_empty() {
+            self.stage_files(files_in_workdir)?;
+        }
 
         log::debug!("{}", "Check Staged".style(hdr_style));
         log::debug!("WorkDir files:\n\t{:?}", self.repo_files_not_staged()?);
@@ -295,17 +297,16 @@ impl GitOps for Client {
         log::debug!("Staged files:\n\t{files_staged_for_commit:?}");
         log::debug!("Branch status: {}", self.branch_status()?);
 
-        log::info!("Commit the staged changes with commit message: {commit_message}");
+        if !files_staged_for_commit.is_empty() {
+            log::info!("Commit the staged changes with commit message: {commit_message}");
+            self.commit_staged(sign, commit_message, prefix, tag_opt)?;
+            log::debug!("{}", "Check Committed".style(hdr_style));
+            log::debug!("WorkDir files:\n\t{:?}", self.repo_files_not_staged()?);
+            let files_staged_for_commit = self.repo_files_staged()?;
+            log::debug!("Staged files:\n\t{files_staged_for_commit:?}");
+        }
 
-        self.commit_staged(sign, commit_message, prefix, tag_opt)?;
-
-        log::debug!("{}", "Check Committed".style(hdr_style));
-        log::debug!("WorkDir files:\n\t{:?}", self.repo_files_not_staged()?);
-
-        let files_staged_for_commit = self.repo_files_staged()?;
-
-        log::debug!("Staged files:\n\t{files_staged_for_commit:?}");
-        log::debug!("Branch status: {}", self.branch_status()?);
+        log::info!("Branch status: {}", self.branch_status()?);
 
         Ok(())
     }


### PR DESCRIPTION
- introduce debug logging for branch status in push command
- facilitate easier debugging and status tracking

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
