### PR TITLE
♻️ refactor(front_matter): update path handling and remove basename usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,8 +346,8 @@ jobs:
             set -ex
 
             ls -la static/s
-            cat static/s/$(ls static/s/*.html)
-            cat static/s/$(ls static/s/registry.json)
+            cat static/s/*.html
+            cat static/s/registry.json
 
       - run:
           name: Git status after drafting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,8 +330,22 @@ jobs:
 
             bin/pcu << parameters.pcu_verbosity >> bsky draft -d 2025-04-01 crates/pcu/tests/bsky-test-blog.md 
             ls -la
+
+      - run:
+          name: Display bluesky post contents
+          command: |
             ls -la bluesky
             cat bluesky/$(ls bluesky)
+
+      - run:
+          name: Display short link contents
+          command: |
+            ls -la static/s
+            cat static/s/$(ls static/s)
+
+      - run:
+          name: Git status after drafting
+          command: |
             git status
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min-rust-version:
     type: string
-    default: "1.81"
+    default: "1.87"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,14 +334,20 @@ jobs:
       - run:
           name: Display bluesky post contents
           command: |
+            set -ex
+
+
             ls -la bluesky
             cat bluesky/$(ls bluesky)
 
       - run:
           name: Display short link contents
           command: |
+            set -ex
+
             ls -la static/s
-            cat static/s/$(ls static/s)
+            cat static/s/$(ls static/s/*.html)
+            cat static/s/$(ls static/s/registry.json)
 
       - run:
           name: Git status after drafting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(gen-bsky)-update cargo package metadata(pr [#635])
 - 💄 style(gen-bsky)-correct license format in Cargo.toml(pr [#636])
 - 👷 ci(circleci)-update workflow branch filter(pr [#637])
+- ♻️ refactor(front_matter)-update path handling and remove basename usage(pr [#641])
 
 ## [0.4.56] - 2025-07-30
 
@@ -1607,6 +1608,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#638]: https://github.com/jerus-org/pcu/pull/638
 [#639]: https://github.com/jerus-org/pcu/pull/639
 [#640]: https://github.com/jerus-org/pcu/pull/640
+[#641]: https://github.com/jerus-org/pcu/pull/641
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.56...HEAD
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56
 [0.4.55]: https://github.com/jerus-org/pcu/compare/v0.4.54...v0.4.55

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 authors = ["jerusdp <jrussell@jerus.ie>"]
-rust-version = "1.81"
+rust-version = "1.87"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/jerus-org/pcu"

--- a/crates/gen-bsky/README.md
+++ b/crates/gen-bsky/README.md
@@ -2,7 +2,7 @@
 
 A library to generate a bluesky post.
 
-[![Rust 1.81+][version-badge]][version-url]
+[![Rust 1.87+][version-badge]][version-url]
 [![circleci-badge]][circleci-url]
 [![Crates.io][crates-badge]][crates-url]
 [![Docs][docs-badge]][docs-url]

--- a/crates/gen-bsky/src/front_matter.rs
+++ b/crates/gen-bsky/src/front_matter.rs
@@ -1,9 +1,10 @@
-use std::{cmp::max, fs::File};
+use std::fs::File;
+use std::{cmp::max, path::PathBuf};
 
 use bsky_sdk::api::app::bsky::feed::post::RecordData;
 use bsky_sdk::api::types::string::Datetime as BskyDatetime;
 use bsky_sdk::rich_text::RichText;
-use link_bridge::Redirector;
+// use link_bridge::Redirector;
 use serde::{Deserialize /* Deserializer */};
 use thiserror::Error;
 use toml::value::Datetime;
@@ -102,10 +103,9 @@ pub struct FrontMatter {
     /// The bluesky section in the front matter. May contain
     /// the bluesky custom keys.
     pub bluesky: Option<Bluesky>,
-    /// The basename for the post.
-    pub basename: Option<String>,
     /// The path to the post.
-    pub path: Option<String>,
+    #[serde(skip)]
+    pub path: PathBuf,
     /// The bluesky post record.
     pub bluesky_post: Option<RecordData>,
     /// The full link to the post.
@@ -219,9 +219,10 @@ impl FrontMatter {
             return Err(FrontMatterError::BlueSkyPostNotConstructed);
         };
 
-        let Some(filename) = &self.basename else {
+        let Some(filename) = self.path.as_path().file_name() else {
             return Err(FrontMatterError::PostBasenameNotSet);
         };
+        let filename = filename.to_str().unwrap();
 
         let Some(post_link) = self.post_link.as_ref() else {
             return Err(FrontMatterError::PostLinkNotSet);
@@ -253,14 +254,11 @@ impl FrontMatter {
         Ok(())
     }
 
-    fn build_post_text(&mut self, base_url: &str) -> Result<String, FrontMatterError> {
-        let post_dir = if let Some(path) = self.path.as_ref() {
-            format!("{}{}", path, "/")
-        } else {
-            String::new()
-        };
+    fn build_post_text(&mut self, _base_url: &str) -> Result<String, FrontMatterError> {
+        let post_dir = self.path.as_path();
+        log::debug!("Building post text with post dir: `{}`", post_dir.display());
 
-        self.get_links(base_url, &post_dir)?;
+        // self.get_links(base_url, &post_dir.as_os_str())?;
 
         if log::log_enabled!(log::Level::Debug) {
             self.log_post_details();
@@ -294,43 +292,39 @@ impl FrontMatter {
         Ok(post_text)
     }
 
-    fn get_links(&mut self, base_url: &str, post_dir: &str) -> Result<(), FrontMatterError> {
-        log::debug!(
-            "Building link with `{base_url}`, `{post_dir}` and `{}`",
-            self.basename.as_ref().unwrap()
-        );
+    // fn get_links(&mut self, base_url: &str, post_dir: &PathBuf) -> Result<(), FrontMatterError> {
+    //     log::debug!(
+    //         "Building link with `{base_url}` and `{}` ",
+    //         post_dir.display()
+    //     );
 
-        let post_link = format!(
-            "/{}/{}",
-            {
-                let link_dir = post_dir.trim_start_matches("content/");
-                link_dir.trim_end_matches("/")
-            },
-            self.basename.as_ref().unwrap()
-        );
+    //     let post_link = format!("/{}/{}", {
+    //         let link_dir = post_dir.to_string_lossy().trim_start_matches("content");
+    //         link_dir.trim_end_matches("/")
+    //     },);
 
-        let mut redirect = Redirector::new(&post_link)?;
+    //     let mut redirect = Redirector::new(&post_link)?;
 
-        let redirect_path = if let Some(redirect_path) = self.short_link_store.as_ref() {
-            log::debug!("redirect path set as `{redirect_path}`");
-            redirect_path
-        } else {
-            log::debug!("redirect path set to default (`static/s`)");
-            "static/s"
-        };
-        redirect.set_path(redirect_path);
+    //     let redirect_path = if let Some(redirect_path) = self.short_link_store.as_ref() {
+    //         log::debug!("redirect path set as `{redirect_path}`");
+    //         redirect_path
+    //     } else {
+    //         log::debug!("redirect path set to default (`static/s`)");
+    //         "static/s"
+    //     };
+    //     redirect.set_path(redirect_path);
 
-        let short_link = redirect.write_redirect()?;
-        log::debug!("redirect written and short link returned: {short_link}");
+    //     let short_link = redirect.write_redirect()?;
+    //     log::debug!("redirect written and short link returned: {short_link}");
 
-        self.post_link = Some(post_link);
-        self.post_short_link = Some(format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            short_link.trim_start_matches("static/"),
-        ));
-        Ok(())
-    }
+    //     self.post_link = Some(post_link);
+    //     self.post_short_link = Some(format!(
+    //         "{}/{}",
+    //         base_url.trim_end_matches('/'),
+    //         short_link.trim_start_matches("static/"),
+    //     ));
+    //     Ok(())
+    // }
 
     #[allow(dead_code)]
     fn set_short_link_store<S: ToString>(&mut self, store: S) {
@@ -424,8 +418,7 @@ mod tests {
         assert_eq!(fm.description, "Test Description");
         assert_eq!(fm.taxonomies.unwrap().tags, vec!["rust", "testing"]);
         assert!(fm.extra.is_none());
-        assert!(fm.basename.is_none());
-        assert!(fm.path.is_none());
+        assert_eq!(fm.path, PathBuf::new());
         assert!(fm.bluesky_post.is_none());
     }
 
@@ -556,19 +549,6 @@ mod tests {
             hashtags,
             vec!["#Rust", "#BlueSky", "#AlreadyHashtag", "#MultiWordTag", "#"]
         );
-    }
-
-    #[test]
-    fn test_front_matter_with_basename_and_path() {
-        let toml = r#"
-            title = "With Path"
-            description = "Has basename and path"
-            basename = "post1"
-            path = "/blog/post1.md"
-        "#;
-        let fm = FrontMatter::from_toml(toml).unwrap();
-        assert_eq!(fm.basename.as_deref(), Some("post1"));
-        assert_eq!(fm.path.as_deref(), Some("/blog/post1.md"));
     }
 
     #[test]
@@ -785,6 +765,8 @@ mod tests {
 
     #[test]
     fn test_date_comparison() {
+        get_test_logger();
+
         let toml = r#"
             title = "Date Comparison"
             description = "Testing date comparison"

--- a/crates/pcu/README.md
+++ b/crates/pcu/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![circleci-badge]][circleci-url]
-[![Rust 1.81+][version-badge]][version-url]
+[![Rust 1.87+][version-badge]][version-url]
 [![FOSSA Status][fossa-badge]][fossa-url]
 [![Docs][docs-badge]][docs-url]
 [![BuyMeaCoffee][bmac-badge]][bmac-url]


### PR DESCRIPTION
- change Rust version badge from 1.81+ to 1.87+ to reflect updated requirements

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
