### PR TITLE
♻️ refactor(draft): improve path handling in DraftBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(front_matter)-update path handling and remove basename usage(pr [#641])
 - ♻️ refactor(bluesky)-update field access in Bluesky struct(pr [#642])
 - ♻️ refactor(taxonomies)-improve tag handling in Taxonomies struct(pr [#644])
+- ♻️ refactor(draft)-improve path handling in DraftBuilder(pr [#645])
 
 ## [0.4.56] - 2025-07-30
 
@@ -1615,6 +1616,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#642]: https://github.com/jerus-org/pcu/pull/642
 [#643]: https://github.com/jerus-org/pcu/pull/643
 [#644]: https://github.com/jerus-org/pcu/pull/644
+[#645]: https://github.com/jerus-org/pcu/pull/645
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.56...HEAD
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56
 [0.4.55]: https://github.com/jerus-org/pcu/compare/v0.4.54...v0.4.55

--- a/crates/gen-bsky/src/draft.rs
+++ b/crates/gen-bsky/src/draft.rs
@@ -97,9 +97,9 @@ impl Draft {
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct DraftBuilder {
-    blog_posts: Vec<FrontMatter>,
     base_url: String,
     store: String,
+    path_or_file: Vec<PathBuf>,
     minimum_date: Datetime,
     allow_draft: bool,
 }
@@ -107,9 +107,9 @@ pub struct DraftBuilder {
 impl Default for DraftBuilder {
     fn default() -> Self {
         DraftBuilder {
-            blog_posts: Vec::default(),
             base_url: String::default(),
             store: String::default(),
+            path_or_file: Vec::new(),
             minimum_date: today(),
             allow_draft: false,
         }
@@ -127,18 +127,26 @@ impl DraftBuilder {
         self
     }
 
-    pub fn add_blog_posts(&mut self, path: &str) -> Result<&mut Self, DraftError> {
+    pub fn add_path_or_file<P: Into<PathBuf>>(
+        &mut self,
+        path_or_file: P,
+    ) -> Result<&mut Self, DraftError> {
+        self.path_or_file.push(path_or_file.into());
+
+        Ok(self)
+    }
+
+    fn add_blog_posts(path: &PathBuf, min_date: Datetime) -> Result<Vec<FrontMatter>, DraftError> {
         // find the potential file in the git repo
         let potential_files = get_files(path)?;
 
-        let mut front_matters = get_front_matters(&potential_files)?;
+        let front_matters = get_front_matters(&potential_files, min_date)?;
 
         if front_matters.is_empty() {
-            log::warn!("no front matters found for path `{path}`");
+            log::warn!("no front matters found for path `{}`", path.display());
         }
 
-        self.blog_posts.append(&mut front_matters);
-        Ok(self)
+        Ok(front_matters)
     }
 
     /// Optionally set a minimum for blog posts
@@ -166,19 +174,17 @@ impl DraftBuilder {
     }
 
     pub fn build(&mut self) -> Result<Draft, DraftError> {
-        if self.blog_posts.is_empty() {
+        let mut blog_posts = Vec::new();
+
+        for path in self.path_or_file.iter() {
+            let mut vec_fm = DraftBuilder::add_blog_posts(path, self.minimum_date)?;
+            blog_posts.append(&mut vec_fm);
+        }
+
+        if blog_posts.is_empty() {
             log::warn!("No blog posts found");
             return Err(DraftError::BlogPostListEmpty);
         }
-
-        let mut blog_posts = self.blog_posts.clone();
-
-        blog_posts.retain(|fm| fm.most_recent_date() >= self.minimum_date);
-        log::trace!(
-            "Retained `{}` front matters after filtering by `{}`",
-            self.blog_posts.len(),
-            self.minimum_date,
-        );
 
         if !self.allow_draft {
             blog_posts.retain(|fm| !fm.draft);
@@ -203,7 +209,7 @@ impl DraftBuilder {
 /// Get the file from the path and return a list of files
 /// The path may be a single file or a directory containing files
 /// Only files ending in `.md` will be returned
-fn get_files(path: &str) -> Result<Vec<PathBuf>, DraftError> {
+fn get_files(path: &PathBuf) -> Result<Vec<PathBuf>, DraftError> {
     let path = PathBuf::from(path);
     log::debug!("get_files path: {path:?}");
     if !path.exists() {
@@ -226,7 +232,7 @@ fn get_files(path: &str) -> Result<Vec<PathBuf>, DraftError> {
             let entry_path = entry?.path();
             log::debug!("Entry path: {entry_path:?}");
             if entry_path.is_dir() {
-                let mut subdir_files = get_files(entry_path.to_str().unwrap())?;
+                let mut subdir_files = get_files(&entry_path)?;
                 files.append(&mut subdir_files);
                 continue;
             } else if entry_path.is_file() && entry_path.extension().unwrap_or_default() == "md" {
@@ -239,23 +245,25 @@ fn get_files(path: &str) -> Result<Vec<PathBuf>, DraftError> {
     }
 }
 
-fn get_front_matters(in_scope_files: &[PathBuf]) -> Result<Vec<FrontMatter>, DraftError> {
+fn get_front_matters(
+    in_scope_files: &[PathBuf],
+    min_date: Datetime,
+) -> Result<Vec<FrontMatter>, DraftError> {
     let mut front_matters = Vec::new();
     let mut first = true;
 
     for path in in_scope_files {
         log::info!("File and path: {path:?}");
-        match get_frontmatter(path, first) {
-            Ok(mut front_matter) => {
-                front_matter.path = path.clone();
-                front_matters.push(front_matter);
-                first = false;
-            }
-            Err(e) => {
-                log::warn!("Error: {e}");
-                first = false;
-                continue;
-            }
+        let fm_res = get_frontmatter(path, first);
+        let Ok(mut fm) = fm_res else {
+            log::warn!("Error: {}", fm_res.err().unwrap());
+            first = false;
+            continue;
+        };
+        fm.path = path.clone();
+        if fm.most_recent_date() >= min_date {
+            front_matters.push(fm);
+            first = false;
         }
     }
 
@@ -339,7 +347,7 @@ mod tests {
         fs::write(&file_path, "test content").unwrap();
 
         println!("File path: {file_path:?}");
-        let result = get_files(file_path.to_str().unwrap());
+        let result = get_files(&file_path);
         println!("Result: {result:#?}");
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), vec![(file_path)]);
@@ -351,7 +359,7 @@ mod tests {
         let file_path = temp_dir.path().join("test.txt");
         fs::write(&file_path, "test content").unwrap();
 
-        let result = get_files(file_path.to_str().unwrap());
+        let result = get_files(&file_path);
         assert!(matches!(
             result,
             Err(DraftError::FileExtensionInvalid(_, _))
@@ -375,7 +383,7 @@ mod tests {
         fs::write(&md_file2, "content2").unwrap();
         fs::write(&txt_file, "content3").unwrap();
 
-        let result = get_files(temp_dir.path().to_str().unwrap());
+        let result = get_files(&temp_dir.path().to_path_buf());
         assert!(result.is_ok());
         let files = result.unwrap();
         println!("Files: {files:?}");
@@ -387,14 +395,14 @@ mod tests {
     #[test]
     fn test_get_files_empty_directory() {
         let temp_dir = TempDir::new().unwrap();
-        let result = get_files(temp_dir.path().to_str().unwrap());
+        let result = get_files(&temp_dir.path().to_path_buf());
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 0);
     }
 
     #[test]
     fn test_get_files_non_existent_path() {
-        let result = get_files("/non-existent/path");
+        let result = get_files(&PathBuf::from("/non-existent/path"));
         assert!(matches!(result, Err(DraftError::PathNotFound(_))));
     }
 
@@ -410,7 +418,7 @@ mod tests {
         fs::write(&md_file1, "content1").unwrap();
         fs::write(&md_file2, "content2").unwrap();
 
-        let result = get_files(temp_dir.path().to_str().unwrap());
+        let result = get_files(&temp_dir.path().to_path_buf());
         assert!(result.is_ok());
         let files = result.unwrap();
         assert_eq!(files.len(), 2);

--- a/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
+++ b/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
@@ -46,7 +46,7 @@ impl CmdDraft {
         let posts_res = posts_builder
             .with_base_url(&base_url)
             .with_store(store)
-            .add_blog_posts(path)?
+            .add_path_or_file(path)?
             .with_minimum_date(self.date)?
             .with_allow_draft(self.allow_draft)
             .build();


### PR DESCRIPTION
- rename method from add_blog_posts to add_path_or_file for clarity and flexibility

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
