### PR TITLE
🐛 fix(cli): correct path handling in cmd_draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 docs(README)-update project title casing(pr [#649])
 - Simplify-and-improve-draft-structure(pr [#650])
 
+### Fixed
+
+- 🐛 cli: correct path handling in cmd_draft(pr [#651])
+
 ## [0.4.56] - 2025-07-30
 
 ### Changed
@@ -1627,6 +1631,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#648]: https://github.com/jerus-org/pcu/pull/648
 [#649]: https://github.com/jerus-org/pcu/pull/649
 [#650]: https://github.com/jerus-org/pcu/pull/650
+[#651]: https://github.com/jerus-org/pcu/pull/651
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.56...HEAD
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56
 [0.4.55]: https://github.com/jerus-org/pcu/compare/v0.4.54...v0.4.55

--- a/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
+++ b/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
@@ -34,7 +34,7 @@ impl CmdDraft {
 
         let base_url = SiteConfig::new()?.base_url();
         let store = &settings.get_string("store")?;
-        if !self.paths.is_empty() {
+        if self.paths.is_empty() {
             self.paths.push(PathBuf::from(DEFAULT_PATH))
         };
 


### PR DESCRIPTION
- fix condition to correctly handle empty paths scenario
- ensure default path is added when no paths are provided

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
