### PR TITLE
✅ test(draft): add comprehensive tests for DraftError variants

### DIFF
--- a/.vscode/ltex.hiddenFalsePositives.en-GB.txt
+++ b/.vscode/ltex.hiddenFalsePositives.en-GB.txt
@@ -56,3 +56,4 @@
 {"rule":"EN_UNPAIRED_QUOTES","sentence":"^\\Qprev_only = \"\"\" 🎉 Congratulations!\\E$"}
 {"rule":"UPPERCASE_SENTENCE_START","sentence":"^\\Qdefault = \"\"\"\\E$"}
 {"rule":"EN_UNPAIRED_QUOTES","sentence":"^\\Qdefault = \"\"\"\\E$"}
+{"rule":"EN_COMPOUNDS_POST_PROCESSING","sentence":"^\\Q✨ add initial Cargo.toml for gen-bsky crate(pr #634)\n✨ add front matter parsing functionality(pr #638)\n✨ add error variants and write bluesky record(pr #639)\n✨ add draft management for blog posts(pr #640)\n✨ add getter method for bluesky field(pr #643)\n✨ add draft allowance option to blog post processing(pr #648)\n✨ add link module for blog post draft(pr #652)\n✨ add smart release tasks(pr #658)\n✨ add URL parse error handling(pr #667)\\E$"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 docs(lib)-enhance documentation and examples(pr [#671])
 - ✅ test(draft)-add comprehensive tests and documentation for add_path_or_file method(pr [#672])
 - 📝 docs(draft)-enhance error documentation(pr [#673])
+- ✅ test(draft)-add comprehensive tests for DraftError variants(pr [#674])
 
 ### Fixed
 
@@ -1675,6 +1676,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#671]: https://github.com/jerus-org/pcu/pull/671
 [#672]: https://github.com/jerus-org/pcu/pull/672
 [#673]: https://github.com/jerus-org/pcu/pull/673
+[#674]: https://github.com/jerus-org/pcu/pull/674
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.56...HEAD
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56
 [0.4.55]: https://github.com/jerus-org/pcu/compare/v0.4.54...v0.4.55

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💄 style(config)-update rustfmt configuration and apply updated rules(pr [#669])
 - 📝 docs(lib)-enhance documentation for gen-bsky(pr [#670])
 - 📝 docs(lib)-enhance documentation and examples(pr [#671])
-- ✅ test(draft)-add comprehensive tests  and documentation for add_path_or_file method(pr [#672])
+- ✅ test(draft)-add comprehensive tests and documentation for add_path_or_file method(pr [#672])
 - 📝 docs(draft)-enhance error documentation(pr [#673])
 
 ### Fixed


### PR DESCRIPTION
- add new rule for EN_COMPOUNDS_POST_PROCESSING to ltex.hiddenFalsePositives.en-GB.txt

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
