### PR TITLE
♻️ refactor(draft): modify return type for write_referrers

### DIFF
--- a/crates/gen-bsky/src/draft.rs
+++ b/crates/gen-bsky/src/draft.rs
@@ -398,13 +398,17 @@ impl Draft {
     /// # Logging
     ///
     /// Failed blog post processing is logged at the `WARN` level with the
-    /// format: ```text
+    /// format:
+    /// ```text
     /// Blog post: `<post_title>` skipped because of error `<error_details>`
     /// ```
     ///
     /// Ensure your logging framework is configured to capture these warnings
     /// for debugging purposes.
-    pub fn write_referrers(&mut self, referrer_store: Option<PathBuf>) -> Result<(), DraftError> {
+    pub fn write_referrers(
+        &mut self,
+        referrer_store: Option<PathBuf>,
+    ) -> Result<&Self, DraftError> {
         let referrer_store = if let Some(p) = referrer_store.as_deref() {
             p
         } else {
@@ -430,7 +434,7 @@ impl Draft {
             }
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Write Bluesky posts for the front matter.

--- a/crates/gen-bsky/src/lib.rs
+++ b/crates/gen-bsky/src/lib.rs
@@ -92,12 +92,14 @@
 //!    
 //!     // Set the filters for blog posts
 //!     builder
-//!     .with_post_store(post_store)?
-//!     .with_referrer_store(referrer_store)?
 //!     .with_minimum_date(date)?
 //!     .with_allow_draft(allow_draft);
-//!    
-//!     builder.build().await
+//!
+//!     // Create the `Draft` structure to write the files
+//!     let mut drafter = builder.build().await?;
+//!
+//!     drafter.write_referrers(Some(referrer_store))?
+//!            .write_bluesky_posts(Some(post_store))?;
 //!
 //!  }
 //! ```

--- a/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
+++ b/crates/pcu/src/cli/bsky/commands/cmd_draft.rs
@@ -63,9 +63,11 @@ impl CmdDraft {
         let mut posts = builder.build().await?;
         log::info!("Initial posts: {posts:#?}");
 
-        posts.write_referrers(None)?;
+        posts
+            .write_referrers(None)?
+            .write_bluesky_posts(None)
+            .await?;
         log::info!("Referrers written: {posts:#?}");
-        posts.write_bluesky_posts(None).await?;
         log::info!("Bluesky posts written: {posts:#?}");
 
         let sign = Sign::Gpg;


### PR DESCRIPTION
- chain write_referrers and write_bluesky_posts methods for cleaner code structure
- log initial posts, referrers, and bluesky posts for better traceability

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
