### PR TITLE
✅ test(draft): add extensive tests for builder() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 docs(draft)-enhance documentation for Bluesky post generation and initial test(pr [#682])
 - ✅ test(draft)-add comprehensive tests for blog post handling(pr [#684])
 - ✅ test(draft)-add comprehensive tests for write_referrers method(pr [#685])
+- ✅ test(draft)-add extensive tests for builder() method(pr [#686])
 
 ### Fixed
 
@@ -1699,6 +1700,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#683]: https://github.com/jerus-org/pcu/pull/683
 [#684]: https://github.com/jerus-org/pcu/pull/684
 [#685]: https://github.com/jerus-org/pcu/pull/685
+[#686]: https://github.com/jerus-org/pcu/pull/686
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.4.56...HEAD
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56
 [0.4.55]: https://github.com/jerus-org/pcu/compare/v0.4.54...v0.4.55

--- a/crates/gen-bsky/src/draft/draft_builder.rs
+++ b/crates/gen-bsky/src/draft/draft_builder.rs
@@ -20,6 +20,17 @@ pub struct DraftBuilder {
     allow_draft: bool,
 }
 
+#[cfg(test)]
+impl DraftBuilder {
+    pub(crate) fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    pub(crate) fn root(&self) -> &PathBuf {
+        &self.root
+    }
+}
+
 impl DraftBuilder {
     /// Start a builder for the draft struct.
     ///


### PR DESCRIPTION
- add test-only methods to access base_url and root for DraftBuilder

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
