### PR TITLE
🐛 fix(cli): correct default log file setting

### DIFF
--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -93,7 +93,7 @@ impl Commands {
     fn get_settings(&self) -> Result<Config, Error> {
         let mut settings = Config::builder()
             // Set defaults for CircleCI
-            .set_default("log", "CHANGELOG.md")?
+            .set_default("log", "PRLOG.md")?
             .set_default("branch", "CIRCLE_BRANCH")?
             .set_default("default_branch", "main")?
             .set_default("pull_request", "CIRCLE_PULL_REQUEST")?


### PR DESCRIPTION
- change default log file from CHANGELOG.md to PRLOG.md to fix incorrect configuration

<!--- Provide a general summary of your changes in the Title above with conventional commit classification. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
