### PR TITLE
revert: undo PRLOG v0.6.3 release

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 👷 ci(circleci)-skip security workflow on main branch(pr [#749])
 - chore-migrate to circleci-toolkit v4.0.1 with rolling images(pr [#772])
 - chore-update prlog compare link to use prlog-v prefix(pr [#774])
+- revert-undo PRLOG v0.6.3 release(pr [#780])
 
 ### Fixed
 
@@ -1893,6 +1894,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#777]: https://github.com/jerus-org/pcu/pull/777
 [#778]: https://github.com/jerus-org/pcu/pull/778
 [#779]: https://github.com/jerus-org/pcu/pull/779
+[#780]: https://github.com/jerus-org/pcu/pull/780
 [Unreleased]: https://github.com/jerus-org/pcu/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/jerus-org/pcu/compare/v0.4.56...v0.5.0
 [0.4.56]: https://github.com/jerus-org/pcu/compare/v0.4.55...v0.4.56


### PR DESCRIPTION
## Summary
- Reverted the PRLOG v0.6.3 release commit
- Deleted v0.6.3 tag from remote

## Problem
The release workflow released PRLOG but the crate releases (gen-bsky, gen-linkedin, pcu) did not complete successfully due to missing `--no-confirm` flag in cargo release command.

The PRLOG was updated assuming all releases would succeed, but since crate releases didn't happen, we need to roll back PRLOG to the unreleased state.

## Changes
- Restored PRLOG.md to show changes under [Unreleased] section
- Removed the [0.6.3] release entry that was created prematurely
- Deleted the v0.6.3 tag from remote (already done)

## Test plan
- [ ] Verify PRLOG.md shows Unreleased section correctly
- [ ] Verify v0.6.3 tag no longer exists on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)