### PR TITLE
fix: remove build_binary from library crates

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -82,8 +82,6 @@ workflows:
           requires: [approve-release]
           package: gen-bsky
           crate_tag_prefix: gen-bsky-v
-          build_binary: true
-          binary_name: gen-bsky
           context:
             - release
             - bot-check
@@ -94,8 +92,6 @@ workflows:
           requires: [release-gen-bsky]
           package: gen-linkedin
           crate_tag_prefix: gen-linkedin-v
-          build_binary: true
-          binary_name: gen-linkedin
           context:
             - release
             - bot-check


### PR DESCRIPTION
## Summary

- Remove `build_binary: true` and `binary_name` from `release-gen-bsky` and `release-gen-linkedin` jobs
- Both are library crates (no `src/main.rs`, no `[[bin]]` in Cargo.toml) — only `pcu` produces a standalone binary
- The release pipeline failed at "Package binary as tar.gz" because there is no binary to package

## Test plan

- [ ] Re-trigger release after merge — gen-bsky and gen-linkedin jobs should complete without binary packaging errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)