### PR TITLE
chore: use toolkit/update_prlog@4.6.0

### DIFF
--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -4,11 +4,6 @@ version: 2.1
 # settings under "Triggers"). Runs independently of the push-triggered config.yml,
 # so the PRLOG update commit does not re-trigger this workflow.
 #
-# NOTE: The GitHub "pr merged" event sets both pipeline.git.branch AND
-# CIRCLE_BRANCH to the PR's HEAD branch (deleted after merge). The custom
-# update-prlog-on-main job switches to main via pcu checkout --branch main,
-# which fetches, switches branch, AND overrides CIRCLE_BRANCH in $BASH_ENV.
-#
 # Workflow:
 #   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main
 #   label         - labels the next queued Renovate PR so it is rebased and runs
@@ -20,61 +15,22 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.5.5
-
-jobs:
-  update-prlog-on-main:
-    # SOURCE: toolkit@4.5.3/jobs/update_prlog
-    # ENHANCEMENT: Uses `pcu checkout --branch main` to handle the GitHub "pr merged"
-    #   event, which sets pipeline.git.branch AND CIRCLE_BRANCH to the PR's HEAD
-    #   branch (now deleted). pcu checkout fetches, switches branch, AND overrides
-    #   CIRCLE_BRANCH in $BASH_ENV — replacing three bash lines with one command.
-    # PLAN: Propose target_branch parameter upstream to toolkit/update_prlog@4.5.4
-    executor: toolkit/rust_env_rolling
-    steps:
-      - checkout
-      - when:
-          condition: << pipeline.parameters.update_pcu >>
-          steps:
-            - toolkit/install_latest_pcu
-      - run:
-          name: Switch to main branch
-          command: pcu checkout --branch main
-      - toolkit/gpg_key
-      - toolkit/git_config
-      - run:
-          name: pcu version
-          command: pcu --version
-      - run:
-          name: Update PRLOG or halt
-          command: |
-            set -e
-
-            # Capture stderr separately so debug logs are visible even when
-            # the step halts (successful pipelines don't surface logs otherwise).
-            result=$(pcu -vvv pr --early-exit --push --from-merge \
-              2>/tmp/pcu_debug.log) || {
-              echo "=== pcu stderr (error) ==="
-              cat /tmp/pcu_debug.log
-              exit 1
-            }
-
-            echo "=== pcu stderr (debug) ==="
-            cat /tmp/pcu_debug.log
-            echo "=== pcu result: '$result' ==="
-
-            if [ "$result" == "halt" ]; then
-              circleci-agent step halt
-            fi
+  toolkit: jerus-org/circleci-toolkit@4.6.0
 
 workflows:
   update_prlog:
     jobs:
-      - update-prlog-on-main:
+      - toolkit/update_prlog:
+          name: update-prlog-on-main
           context:
             - release
             - bot-check
             - pcu-app
+          min_rust_version: "1.88"
+          target_branch: "main"
+          pcu_from_merge: --from-merge
+          update_pcu: << pipeline.parameters.update_pcu >>
+          pcu_verbosity: "-vvv"
       - toolkit/label:
           min_rust_version: "1.88"
           context: pcu-app


### PR DESCRIPTION
## Summary

- Replaces custom `update-prlog-on-main` job with `toolkit/update_prlog@4.6.0`
- Removes SSH fingerprint dependency

## Background

The custom job was a workaround for the missing `target_branch` parameter in the toolkit. toolkit@4.6.0 adds `target_branch: "main"` support and makes `ssh_fingerprint` optional, so the custom job is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)