### PR TITLE
chore: rolling builds, remove check_last_commit, bump toolkit to 4.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,9 @@ parameters:
   min_rust_version:
     type: string
     default: "1.88"
-  validation_flag:
-    type: boolean
-    default: false
-    description: "If true, the validation pipeline will be executed."
 orbs:
   # cci-ignore-next-line
-  toolkit: jerus-org/circleci-toolkit@4.5.5
+  toolkit: jerus-org/circleci-toolkit@4.7.0
 
 # Custom executors removed - using toolkit rolling executors instead:
 #   - toolkit/rust_env_rolling for Rust jobs
@@ -266,28 +262,7 @@ jobs:
             git status
 
 workflows:
-  check_last_commit:
-    when:
-      and:
-        - not:
-            equal: ["main", << pipeline.git.branch >>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.validation_flag >>
-
-    jobs:
-      - toolkit/choose_pipeline:
-          name: choose pipeline based on committer
-          context: bot-check
-
   validation:
-    when:
-      or:
-        - equal: ["main", << pipeline.git.branch >>]
-        - and:
-            - << pipeline.parameters.validation_flag >>
-            - not:
-                equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       # Signature verification for trusted PRs (with write access for comments)
       - toolkit/verify_commit_signatures:
@@ -308,10 +283,10 @@ workflows:
           filters:
             branches:
               only: /pull\/[0-9]+/
-      - toolkit/required_builds:
+      - toolkit/required_builds_rolling:
           name: required-builds-all
           min_rust_version: << pipeline.parameters.min_rust_version >>
-      - toolkit/required_builds:
+      - toolkit/required_builds_rolling:
           name: build-<< matrix.cargo_package >>
           matrix:
             parameters:
@@ -345,7 +320,6 @@ workflows:
             - required-builds-all
             # cci-ignore-next-line
             - build-pcu
-            - toolkit/required_builds
             - docs
             - toolkit/idiomatic_rust
       - test-push:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -33,7 +33,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.5.5
+  toolkit: jerus-org/circleci-toolkit@4.7.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.6.0
+  toolkit: jerus-org/circleci-toolkit@4.7.0
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

- Bump `circleci-toolkit` to `4.7.0` across all three pipeline files
- Replace `toolkit/required_builds` → `toolkit/required_builds_rolling` (both the `required-builds-all` and `build-<matrix>` instances)
- Remove `check_last_commit` workflow and `toolkit/choose_pipeline` job
- Remove `validation_flag` parameter
- Remove `when:` condition from `validation` workflow
- Remove stale `- toolkit/required_builds` from `test-commit` requires list

🤖 Generated with [Claude Code](https://claude.com/claude-code)