### PR TITLE
fix: add app/renovate to default label authors

### DIFF
--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -76,7 +76,7 @@ pub enum Commands {
     #[clap(long_about = "
 Apply a label to a pull request.
 In default use applies the `rebase` label to the pull request with
-the lowest number submitted by the `renovate` user")]
+the lowest number submitted by the `renovate` or `app/renovate` user")]
     Label(Label),
     /// Post summaries and link to new or changed blog posts to bluesky
     Bsky(Bsky),

--- a/crates/pcu/src/cli/label.rs
+++ b/crates/pcu/src/cli/label.rs
@@ -6,7 +6,7 @@ use crate::Error;
 /// Configuration for the Rebase command
 #[derive(Debug, Parser, Clone)]
 pub struct Label {
-    /// Override the default allowed authors (renovate, mend) when selecting the pull
+    /// Override the default allowed authors (renovate, mend, app/renovate) when selecting the pull
     /// request to label
     #[arg(short, long)]
     pub author: Vec<String>,

--- a/crates/pcu/src/ops/git_ops.rs
+++ b/crates/pcu/src/ops/git_ops.rs
@@ -23,7 +23,7 @@ use crate::{
 
 const GIT_USER_SIGNATURE: &str = "user.signingkey";
 const DEFAULT_COMMIT_MESSAGE: &str = "chore: commit staged files";
-const DEFAULT_REBASE_LOGINS: &str = "renovate,mend";
+const DEFAULT_REBASE_LOGINS: &str = "renovate,mend,app/renovate";
 
 #[derive(ValueEnum, Debug, Default, Clone, Copy, PartialEq)]
 pub enum Sign {
@@ -965,6 +965,22 @@ mod tests {
     use super::*;
     use git2::Signature;
     use rstest::rstest;
+
+    #[test]
+    fn test_default_rebase_logins_includes_app_renovate() {
+        let logins: Vec<&str> = DEFAULT_REBASE_LOGINS.split(',').collect();
+        assert!(
+            logins.contains(&"app/renovate"),
+            "DEFAULT_REBASE_LOGINS should include 'app/renovate' (GitHub App bot login), got: {logins:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_rebase_logins_preserves_existing_defaults() {
+        let logins: Vec<&str> = DEFAULT_REBASE_LOGINS.split(',').collect();
+        assert!(logins.contains(&"renovate"), "should include 'renovate'");
+        assert!(logins.contains(&"mend"), "should include 'mend'");
+    }
 
     #[test]
     fn test_sign_default() {


### PR DESCRIPTION
## Summary

- GitHub App Renovate bot creates PRs with author login `app/renovate`, not `renovate`
- `pcu label` default allowed authors (`renovate,mend`) silently found no matching PRs
- Result: `label_next_pr` applied no label; no error was raised
- Fix: add `app/renovate` to `DEFAULT_REBASE_LOGINS`

## Test plan

- [x] RED: `test_default_rebase_logins_includes_app_renovate` fails without fix
- [x] GREEN: both new tests pass with fix; full suite 75/75

🤖 Generated with [Claude Code](https://claude.com/claude-code)