### PR TITLE
chore: migrate CI to circleci-toolkit 6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.88"
 orbs:
   # cci-ignore-next-line
-  toolkit: jerus-org/circleci-toolkit@4.8.0
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 # Custom executors removed - using toolkit rolling executors instead:
 #   - toolkit/rust_env_rolling for Rust jobs
@@ -283,10 +283,10 @@ workflows:
           filters:
             branches:
               only: /pull\/[0-9]+/
-      - toolkit/required_builds_rolling:
+      - toolkit/required_builds:
           name: required-builds-all
           min_rust_version: << pipeline.parameters.min_rust_version >>
-      - toolkit/required_builds_rolling:
+      - toolkit/required_builds:
           name: build-<< matrix.cargo_package >>
           matrix:
             parameters:
@@ -296,22 +296,19 @@ workflows:
             branches:
               ignore: main
       - toolkit/optional_builds:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main
       - toolkit/test_doc_build:
           name: docs
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main
-      - toolkit/common_tests_rolling:
+      - toolkit/common_tests:
           min_rust_version: << pipeline.parameters.min_rust_version >>
           test_runner: nextest
           nextest_profile: ci
       - toolkit/idiomatic_rust:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -33,7 +33,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.8.0
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.8.0
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 workflows:
   update_prlog:
@@ -26,13 +26,11 @@ workflows:
             - release
             - bot-check
             - pcu-app
-          min_rust_version: "1.88"
           target_branch: "main"
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
       - toolkit/label:
-          min_rust_version: "1.88"
           context: pcu-app
           requires:
             - update-prlog-on-main


### PR DESCRIPTION
## Summary

- Migrate all 3 CI files from `jerus-org/circleci-toolkit@4.8.0` to `6.0.0`
- Rename `required_builds_rolling` → `required_builds` (two instances)
- Rename `common_tests_rolling` → `common_tests`
- Remove `min_rust_version` from jobs that no longer accept it

🤖 Generated with [Claude Code](https://claude.com/claude-code)