### PR TITLE
fix(logging): add gen_linkedin to log filter

### DIFF
--- a/crates/pcu/src/bin/main.rs
+++ b/crates/pcu/src/bin/main.rs
@@ -90,6 +90,7 @@ fn get_logging(level: &log::LevelFilter) -> env_logger::Builder {
     builder.filter_module("pcu::utilities", *level);
     builder.filter_module("pcu", *level);
     builder.filter_module("gen_bsky", *level);
+    builder.filter_module("gen_linkedin", *level);
     builder.format_timestamp_secs();
 
     builder


### PR DESCRIPTION
## Summary

- `gen_bsky` was registered in pcu's `env_logger` filter but `gen_linkedin` was not
- All `gen_linkedin` log messages (DEBUG, INFO, WARN) were silenced by the default `"off"` filter level
- At `-vv` (INFO level), API failure warnings from `pcu linkedin post` were completely invisible
- The symptom: `"No LinkedIn posts found."` with no preceding warn, making it impossible to diagnose whether the issue was empty store vs API failure

One-line fix: add `builder.filter_module("gen_linkedin", *level)` alongside `gen_bsky`.

After this fix, at `-vv` (INFO), LinkedIn API errors will appear as:
```
WARN  gen_linkedin::post] Failed to post to LinkedIn: <api error>
```

## Test plan

- [ ] `cargo test -p gen-linkedin` passes
- [ ] `cargo test -p pcu` passes
- [ ] CI passes
- [ ] Trigger `pcu linkedin post` in a release pipeline and confirm API errors are now visible in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)