### PR TITLE
chore: group git2 + git2_credentials in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "extends": [
     "github>jerusdp/renovate-config:default.json"
+  ],
+  "packageRules": [
+    {
+      "description": "Group git2 and git2_credentials — git2_credentials re-exports git2 types so both must move together",
+      "matchPackageNames": ["/^git2/", "/^git2_credentials/"],
+      "groupName": "git2 packages"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- `git2_credentials` re-exports `git2` types (`Config`, `Cred`, `CredentialType`) in its public API — both crates must always be upgraded in the same PR
- Without this group, Renovate created PR #955 bumping only `git2` to `0.21.0`, which fails to compile because `git2_credentials 0.15.0` still depends on `git2 0.20.4`
- The pattern mirrors the `rand packages` group documented in CLAUDE.md

## Relationship to PR #955

PR #955 (`fix(deps): update rust crate git2 to 0.21.0`) should be closed — it cannot be merged until `git2_credentials` releases a version that supports `git2 0.21.0`. Once that happens, Renovate will create a single grouped PR updating both crates together.

Note: `git2 0.21.0` also has API changes (`summary()`, `url()`, `shorthand()` return types changed) that will need code fixes in the same future PR.

## Test plan

- [ ] Confirm CI passes
- [ ] Close PR #955 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)