### PR TITLE
chore: toolkit 6.3.0 + ignore RUSTSEC-2026-0173

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -25,6 +25,18 @@ ignore = [
     # Remove when sigstore updates its syntax-parsing dependencies.
     "RUSTSEC-2024-0370",
 
+    # RUSTSEC-2026-0173: proc-macro-error2 2.0.1 — unmaintained (2026-06-07).
+    # The proc-macro-error2 repo is ARCHIVED, so it will never be patched.
+    # Fix attempted: no fixed upstream exists. Two transitive paths:
+    #   sigstore → oci-client → oci-spec → getset → proc-macro-error2
+    #     (getset is the blocker: inactive since 2025-06; jbaublitz/getset#132)
+    #   gen-bsky → aquamarine → proc-macro-error2 (aquamarine is docs-only)
+    # Unmaintained != vulnerable; no known CVE. Upstream tracking:
+    # jbaublitz/getset#132, youki-dev/oci-spec-rs#340 (filed by us).
+    # TEMPORARY — reviewed weekly; remove when a fixed getset/oci-spec ships
+    # (and once gen-bsky drops aquamarine).
+    "RUSTSEC-2026-0173",
+
 ]
 
 # Yanked-package checking re-enabled: core2 0.4.0 was removed from the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.88"
 orbs:
   # cci-ignore-next-line
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 # Custom executors removed - using toolkit rolling executors instead:
 #   - toolkit/rust_env_rolling for Rust jobs
@@ -835,7 +835,7 @@ workflows:
               only:
                 - main
                 - /pull\/[0-9]+/
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370"
+          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370 RUSTSEC-2026-0173"
       - toolkit/security:
           name: security with sonarcloud
           context: SonarCloud
@@ -844,6 +844,6 @@ workflows:
               ignore:
                 - /pull\/[0-9]+/
                 - main
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370"
+          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370 RUSTSEC-2026-0173"
 
 

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -33,7 +33,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

Two CI-green fixes:

1. **`jerus-org/circleci-toolkit@6.2.0 → 6.3.0`** (config.yml, release.yml, update_prlog.yml) — codecov orb 6.0.0 resolves the org-wide `gpg: no valid OpenPGP data found` Codecov upload failure.
2. **Ignore `RUSTSEC-2026-0173`** (`proc-macro-error2` unmaintained) in **both** `.cargo/audit.toml` and the `security` job `ignore_advisories` (kept in sync per this repo's policy).

## On the audit ignore

`proc-macro-error2` was flagged unmaintained on 2026-06-07 and its repo is **archived** (will never be patched). pcu pulls it transitively via two paths:

- `sigstore → oci-client → oci-spec → getset → proc-macro-error2` — `getset` is the blocker (inactive since 2025-06). Tracked: jbaublitz/getset#132; we filed youki-dev/oci-spec-rs#340 asking the active oci-spec maintainers to drop getset.
- `gen-bsky → aquamarine → proc-macro-error2` — `aquamarine` is a docs-only macro; its removal from gen-bsky is a separate in-house fix.

Unmaintained ≠ vulnerable (no CVE). The ignore is **temporary, documented, and weekly-reviewed**; it'll be removed as soon as a fixed `getset`/`oci-spec` ships (and gen-bsky drops aquamarine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
