### PR TITLE
chore(gen-bsky): aquamarine -> simple-mermaid

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,14 +27,14 @@ ignore = [
 
     # RUSTSEC-2026-0173: proc-macro-error2 2.0.1 — unmaintained (2026-06-07).
     # The proc-macro-error2 repo is ARCHIVED, so it will never be patched.
-    # Fix attempted: no fixed upstream exists. Two transitive paths:
+    # Fix attempted: no fixed upstream exists. Remaining transitive path:
     #   sigstore → oci-client → oci-spec → getset → proc-macro-error2
     #     (getset is the blocker: inactive since 2025-06; jbaublitz/getset#132)
-    #   gen-bsky → aquamarine → proc-macro-error2 (aquamarine is docs-only)
+    # (The gen-bsky → aquamarine path was removed: aquamarine replaced with the
+    #  zero-dependency simple-mermaid for rustdoc diagrams.)
     # Unmaintained != vulnerable; no known CVE. Upstream tracking:
     # jbaublitz/getset#132, youki-dev/oci-spec-rs#340 (filed by us).
-    # TEMPORARY — reviewed weekly; remove when a fixed getset/oci-spec ships
-    # (and once gen-bsky drops aquamarine).
+    # TEMPORARY — reviewed weekly; remove when a fixed getset/oci-spec ships.
     "RUSTSEC-2026-0173",
 
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,20 +119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1702,6 @@ dependencies = [
 name = "gen-bsky"
 version = "0.1.23"
 dependencies = [
- "aquamarine",
  "base62",
  "bsky-sdk",
  "chrono",
@@ -1726,6 +1711,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "simple-mermaid",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2296,25 +2282,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -4930,6 +4897,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-mermaid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589144a964b4b30fe3a83b4bb1a09e2475aac194ec832a046a23e75bddf9eb29"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ rust-version = "1.88"
 repository = "https://github.com/jerus-org/pcu"
 
 [workspace.dependencies]
-aquamarine = "0.6.0"
 base64 = "0.22.1"
+simple-mermaid = "0.2.0"
 base62 = "2.2.4"
 bsky-sdk = "0.1.24"
 cargo_toml = "0.22.3"

--- a/crates/gen-bsky/Cargo.toml
+++ b/crates/gen-bsky/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 keywords = ["ci", "github", "bluesky"]
 include = [
     "**/*.rs",
+    "**/*.mmd",
+    "doc/mermaid-init.html",
     "Cargo.toml",
     "README.md",
     "LICENSE-MIT",
@@ -18,9 +20,15 @@ include = [
 ]
 categories = ["development-tools::build-utils"]
 
+[package.metadata.docs.rs]
+# simple-mermaid renders the .mmd diagrams via mermaid.js injected into the
+# rustdoc header (replaces the former aquamarine proc-macro, which pulled the
+# now-archived proc-macro-error2).
+rustdoc-args = ["--html-in-header", "doc/mermaid-init.html"]
+
 [dependencies]
-aquamarine.workspace = true
 base62.workspace = true
+simple-mermaid.workspace = true
 bsky-sdk.workspace = true
 chrono.workspace = true
 link-bridge.workspace = true

--- a/crates/gen-bsky/doc/mermaid-init.html
+++ b/crates/gen-bsky/doc/mermaid-init.html
@@ -1,0 +1,4 @@
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/hashtags_pipeline.mmd
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/hashtags_pipeline.mmd
@@ -1,0 +1,5 @@
+graph LR
+    A["Input: 'rust programming'"] --> B["Split: ['rust', 'programming']"]
+    B --> C["Capitalize: ['Rust', 'Programming']"]
+    C --> D["Join: 'RustProgramming'"]
+    D --> E["Prefix: '#RustProgramming'"]

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/tags.rs
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/tags.rs
@@ -4,7 +4,6 @@ use std::fmt::Display;
 
 use crate::Capitalise;
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Hashtags Function Documentation
 ///
 /// ## Overview
@@ -42,13 +41,7 @@ use crate::Capitalise;
 ///
 /// ### Processing Pipeline
 ///
-/// ```mermaid
-/// graph LR
-///     A["Input: 'rust programming'"] --> B["Split: ['rust', 'programming']"]
-///     B --> C["Capitalize: ['Rust', 'Programming']"]
-///     C --> D["Join: 'RustProgramming'"]
-///     D --> E["Prefix: '#RustProgramming'"]
-/// ```
+#[doc = simple_mermaid::mermaid!("hashtags_pipeline.mmd")]
 ///
 /// ## Input Format Handling
 ///

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/taxonomies.rs
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/taxonomies.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Taxonomies Module Documentation
 ///
 /// ## Overview
@@ -19,15 +18,7 @@
 ///
 /// ## Module Architecture
 ///
-/// ```mermaid
-/// graph TD
-///     A["Markdown File"] --> B["TOML Front Matter"]
-///     B --> C["FrontMatter Struct"]
-///     C --> D["Taxonomies Struct"]
-///     D --> E["Raw Tags"]
-///     D --> F["Formatted Hashtags"]
-///     F --> G["Social Media Posts"]
-/// ```
+#[doc = simple_mermaid::mermaid!("taxonomies_architecture.mmd")]
 ///
 /// ## Integration With Other Modules
 ///

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/taxonomies_architecture.mmd
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/taxonomies_architecture.mmd
@@ -1,0 +1,7 @@
+graph TD
+    A["Markdown File"] --> B["TOML Front Matter"]
+    B --> C["FrontMatter Struct"]
+    C --> D["Taxonomies Struct"]
+    D --> E["Raw Tags"]
+    D --> F["Formatted Hashtags"]
+    F --> G["Social Media Posts"]

--- a/crates/gen-bsky/src/post.rs
+++ b/crates/gen-bsky/src/post.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Post Module Documentation
 ///
 /// ## Overview
@@ -9,17 +8,7 @@
 ///
 /// ## Module Architecture
 ///
-/// ```mermaid
-/// graph TD
-///     A["Post Files (.post)"] --> B["Post::load()"]
-///     B --> C["BskyPost Collection"]
-///     C --> D["Post::post_to_bluesky()"]
-///     D --> E["Bluesky Authentication"]
-///     E --> F["Publish Posts"]
-///     F --> G["Update Post States"]
-///     G --> H["Post::delete_posted_posts()"]
-///     H --> I["Cleanup Files"]
-/// ```
+#[doc = simple_mermaid::mermaid!("post_architecture.mmd")]
 ///
 /// ## Post Lifecycle
 ///
@@ -29,14 +18,7 @@
 /// 2. **Posted**: Posts have been successfully published to Bluesky
 /// 3. **Deleted**: Post files have been cleaned up after successful publishing
 ///
-/// ```mermaid
-/// stateDiagram-v2
-///     [*] --> Read: Load from file
-///     Read --> Posted: Successful publish
-///     Read --> Read: Publish error
-///     Posted --> Deleted: File cleanup
-///     Deleted --> [*]
-/// ```
+#[doc = simple_mermaid::mermaid!("post_lifecycle.mmd")]
 ///
 /// ## Key Components
 ///

--- a/crates/gen-bsky/src/post_architecture.mmd
+++ b/crates/gen-bsky/src/post_architecture.mmd
@@ -1,0 +1,9 @@
+graph TD
+    A["Post Files (.post)"] --> B["Post::load()"]
+    B --> C["BskyPost Collection"]
+    C --> D["Post::post_to_bluesky()"]
+    D --> E["Bluesky Authentication"]
+    E --> F["Publish Posts"]
+    F --> G["Update Post States"]
+    G --> H["Post::delete_posted_posts()"]
+    H --> I["Cleanup Files"]

--- a/crates/gen-bsky/src/post_lifecycle.mmd
+++ b/crates/gen-bsky/src/post_lifecycle.mmd
@@ -1,0 +1,6 @@
+stateDiagram-v2
+    [*] --> Read: Load from file
+    Read --> Posted: Successful publish
+    Read --> Read: Publish error
+    Posted --> Deleted: File cleanup
+    Deleted --> [*]


### PR DESCRIPTION
## Summary

Replaces the `aquamarine` rustdoc-mermaid macro in `gen-bsky` with **`simple-mermaid`**, removing the `gen-bsky → aquamarine → proc-macro-error2` path. `proc-macro-error2` is unmaintained and its repo is **archived** (RUSTSEC-2026-0173); `aquamarine` is its last release and can't move off it. `simple-mermaid` is a **zero-dependency** declarative macro, so the diagrams still render in rustdoc but no problematic transitive deps are pulled in.

## Changes

- **Diagrams extracted** to `.mmd` files next to their modules: `post_architecture.mmd`, `post_lifecycle.mmd`, `hashtags_pipeline.mmd`, `taxonomies_architecture.mmd`.
- **Source**: removed `#[cfg_attr(doc, aquamarine::aquamarine)]` + the inline ```mermaid blocks; replaced with `#[doc = simple_mermaid::mermaid!("…​.mmd")]` (fully-qualified — no import needed).
- **Manifests**: `aquamarine` → `simple-mermaid` (workspace + crate); added `[package.metadata.docs.rs]` `rustdoc-args` pointing at `doc/mermaid-init.html` (loads mermaid.js); added `**/*.mmd` and the header to the crate `include` list so `include_str!` resolves on docs.rs / `cargo publish`.
- **`.cargo/audit.toml`**: dropped the aquamarine path from the RUSTSEC-2026-0173 note. The **getset path remains** (`sigstore → oci-client → oci-spec → getset`), so the temporary ignore stays — this PR just removes one of the two paths.

## Verification

- `cargo build -p gen-bsky` ✅, `cargo doc -p gen-bsky` (with the header) ✅ — the `mermaid!` macro + `include_str!` resolve.
- `cargo fmt --all --check` ✅, `cargo clippy -p gen-bsky --all-targets --all-features -- -D warnings` ✅.
- Lockfile: **aquamarine removed**, simple-mermaid added (zero deps); `proc-macro-error2` remains only via the getset path.

Diagram *rendering* is a docs.rs/browser concern (mermaid.js via the injected header); the source builds and the diagram content is preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
