### PR TITLE
feat: explicit GPG signing key on SignConfig (closes #976)

### DIFF
--- a/crates/pcu/src/ops/git_ops.rs
+++ b/crates/pcu/src/ops/git_ops.rs
@@ -52,6 +52,10 @@ pub struct SignConfig {
     /// Explicit commit identity. When `None`, the signature is read from the
     /// repository's merged git config (the previous behaviour).
     pub identity: Option<CommitIdentity>,
+    /// Explicit GPG signing key id. When `None`, the key is read from
+    /// `user.signingkey` in the repository's git config (the previous
+    /// behaviour). Only consulted for `Sign::Gpg`.
+    pub signing_key: Option<String>,
 }
 
 impl Default for SignConfig {
@@ -60,6 +64,7 @@ impl Default for SignConfig {
             sign: Sign::Gpg,
             signoff: true,
             identity: None,
+            signing_key: None,
         }
     }
 }
@@ -71,6 +76,7 @@ impl SignConfig {
             sign,
             signoff: true,
             identity: None,
+            signing_key: None,
         }
     }
 
@@ -80,6 +86,7 @@ impl SignConfig {
             sign,
             signoff,
             identity: None,
+            signing_key: None,
         }
     }
 
@@ -91,6 +98,19 @@ impl SignConfig {
             email: email.into(),
         });
         self
+    }
+
+    /// Supply an explicit GPG signing key id, used directly instead of reading
+    /// `user.signingkey` from the git config.
+    pub fn with_signing_key(mut self, key: impl Into<String>) -> Self {
+        self.signing_key = Some(key.into());
+        self
+    }
+
+    /// The explicit GPG signing key, if one is configured. When `None`, callers
+    /// fall back to `user.signingkey` from the repository's git config.
+    pub(crate) fn explicit_signing_key(&self) -> Option<&str> {
+        self.signing_key.as_deref()
     }
 
     /// Build a signature from the explicit identity, if one is configured.
@@ -557,9 +577,14 @@ impl GitOps for Client {
                 )?;
                 let commit_str = std::str::from_utf8(&commit_buffer).unwrap();
 
-                let signature = self.git_repo.config()?.get_string(GIT_USER_SIGNATURE)?;
+                // Prefer an explicit signing key supplied by the caller; fall
+                // back to `user.signingkey` from the git config otherwise.
+                let signature = match sign_config.explicit_signing_key() {
+                    Some(key) => key.to_string(),
+                    None => self.git_repo.config()?.get_string(GIT_USER_SIGNATURE)?,
+                };
 
-                let short_sign = signature[12..].to_string();
+                let short_sign = signature.get(12..).unwrap_or(signature.as_str());
                 log::trace!("Signature short: {short_sign}");
 
                 let gpg_args = vec!["--status-fd", "2", "-bsau", signature.as_str()];
@@ -1210,6 +1235,17 @@ mod tests {
     fn explicit_signature_is_none_without_identity() {
         let config = SignConfig::new(Sign::None);
         assert!(config.explicit_signature().unwrap().is_none());
+    }
+
+    #[test]
+    fn with_signing_key_sets_explicit_key() {
+        let config = SignConfig::new(Sign::Gpg).with_signing_key("DEADBEEFCAFE");
+        assert_eq!(config.explicit_signing_key(), Some("DEADBEEFCAFE"));
+    }
+
+    #[test]
+    fn explicit_signing_key_is_none_by_default() {
+        assert_eq!(SignConfig::new(Sign::Gpg).explicit_signing_key(), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #976.

## Problem

`#972` made the commit author/committer identity explicit, but the `Sign::Gpg` path still read the signing key from git config:

```rust
const GIT_USER_SIGNATURE: &str = "user.signingkey";
let signature = self.git_repo.config()?.get_string(GIT_USER_SIGNATURE)?;
```

So a signed commit still depended on `user.signingkey` being visible in the repo's merged config — the same `safe.directory`/dubious-ownership fragility, for the one remaining value.

## Change

Add an optional explicit signing key to `SignConfig`, mirroring `with_identity`:

```rust
let cfg = SignConfig::new(Sign::Gpg)
    .with_identity(name, email)
    .with_signing_key(key_id);
```

- New `SignConfig.signing_key: Option<String>` + builder `with_signing_key(key)`.
- New accessor `explicit_signing_key() -> Option<&str>`.
- `commit_staged`'s `Sign::Gpg` arm uses the explicit key when set, falling back to `config().get_string("user.signingkey")` when absent (unchanged behaviour).
- Hardened the trace-log key slice (`signature.get(12..)`) so a short explicit key can't panic.

Combined with `#972`, a caller holding the key (e.g. via `BOT_SIGN_KEY`) can produce a signed commit with **zero** git-config dependency.

## Tests (RED/GREEN TDD)

- `with_signing_key_sets_explicit_key`
- `explicit_signing_key_is_none_by_default`

## Validation

- `cargo test -p pcu --all-targets` ✅ 195 passed
- `cargo fmt --all --check` ✅ · `cargo clippy --all --tests --all-features -- -D warnings` ✅ · `cargo audit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
