### PR TITLE
feat: add --skip-ci to pcu pr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min_rust_version:
     type: string
-    default: "1.88"
+    default: "1.89"
 orbs:
   # cci-ignore-next-line
   toolkit: jerus-org/circleci-toolkit@6.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 authors = ["jerusdp <jrussell@jerus.ie>"]
-rust-version = "1.88"
+rust-version = "1.89"
 repository = "https://github.com/jerus-org/pcu"
 
 [workspace.dependencies]

--- a/crates/pcu/README.md
+++ b/crates/pcu/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![circleci-badge]][circleci-url]
-[![Rust 1.88+][version-badge]][version-url]
+[![Rust 1.89+][version-badge]][version-url]
 [![FOSSA Status][fossa-badge]][fossa-url]
 [![Docs][docs-badge]][docs-url]
 [![BuyMeaCoffee][bmac-badge]][bmac-url]
@@ -15,7 +15,7 @@
 [mit-url]: https://github.com/jerusdp/pcu/blob/main/LICENSE
 [circleci-badge]: https://dl.circleci.com/status-badge/img/gh/jerus-org/pcu/tree/main.svg?style=svg
 [circleci-url]: https://dl.circleci.com/status-badge/redirect/gh/jerus-org/pcu/tree/main
-[version-badge]: https://img.shields.io/badge/rust-1.81+-orange.svg
+[version-badge]: https://img.shields.io/badge/rust-1.89+-orange.svg
 [version-url]: https://www.rust-lang.org
 [fossa-badge]: https://app.fossa.com/api/projects/custom%2B22707%2Fgit%40github.com%3Ajerus-org%2Fpcu.git.svg?type=shield&issueType=license
 [fossa-url]: (https://app.fossa.com/projects/custom%2B22707%2Fgit%40github.com%3Ajerus-org%2Fpcu.git?ref=badge_shield&issueType=license)

--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -155,10 +155,19 @@ impl Commands {
         log::trace!("Initial settings (default, pcu.toml and environment: {settings:#?}");
 
         settings = match self {
-            Commands::Pr(pr) => settings
-                .set_override("commit_message", "chore: update prlog for pr")?
-                .set_override("command", "pr")?
-                .set_override("from_merge", pr.from_merge)?,
+            Commands::Pr(pr) => {
+                // Append [skip ci] so the push of the PRLOG update to the
+                // default branch does not trigger a redundant CI pipeline.
+                let commit_message = if pr.skip_ci {
+                    "chore: update prlog for pr [skip ci]"
+                } else {
+                    "chore: update prlog for pr"
+                };
+                settings
+                    .set_override("commit_message", commit_message)?
+                    .set_override("command", "pr")?
+                    .set_override("from_merge", pr.from_merge)?
+            }
             Commands::Release(_) => settings
                 .set_override("commit_message", "chore: update prlog for release")?
                 .set_override("command", "release")?,
@@ -283,6 +292,42 @@ mod tests {
     use super::*;
     use crate::SignConfig;
     use clap::Parser;
+
+    #[test]
+    fn pr_skip_ci_appends_to_commit_message() {
+        let cmd = Commands::Pr(Pr {
+            early_exit: false,
+            from_merge: true,
+            prefix: "v".to_string(),
+            push: true,
+            allow_push_fail: true,
+            allow_no_pull_request: true,
+            skip_ci: true,
+        });
+        let settings = cmd.get_settings().unwrap();
+        assert_eq!(
+            settings.get::<String>("commit_message").unwrap(),
+            "chore: update prlog for pr [skip ci]"
+        );
+    }
+
+    #[test]
+    fn pr_without_skip_ci_has_plain_commit_message() {
+        let cmd = Commands::Pr(Pr {
+            early_exit: false,
+            from_merge: true,
+            prefix: "v".to_string(),
+            push: true,
+            allow_push_fail: true,
+            allow_no_pull_request: true,
+            skip_ci: false,
+        });
+        let settings = cmd.get_settings().unwrap();
+        assert_eq!(
+            settings.get::<String>("commit_message").unwrap(),
+            "chore: update prlog for pr"
+        );
+    }
 
     #[test]
     fn test_cli_default_signoff_enabled() {

--- a/crates/pcu/src/cli/pull_request.rs
+++ b/crates/pcu/src/cli/pull_request.rs
@@ -34,6 +34,11 @@ pub struct Pr {
     /// request was found in CI environment.
     #[clap(long, default_value_t = true)]
     pub allow_no_pull_request: bool,
+    /// Append `[skip ci]` to the PRLOG commit message so the push to the default
+    /// branch does not trigger a redundant CI pipeline (e.g. the second
+    /// validation run after a "pr merged" PRLOG update).
+    #[clap(long, default_value_t = false)]
+    pub skip_ci: bool,
 }
 
 impl Pr {


### PR DESCRIPTION
## Summary

`pcu pr --skip-ci` appends ` [skip ci]` to the PRLOG commit message:

```
chore: update prlog for pr [skip ci]
```

so the push of the PRLOG update to the default branch does not trigger a redundant CI pipeline.

## Motivation

On a GitHub "pull_request merged" event, validation runs on main; then the PRLOG update (pushed by `pcu pr --push`) is a second push to main that triggers a **second, redundant** validation run. `--skip-ci` suppresses it.

The commit message is `set_override` inside pcu and `--push` is atomic here, so the flag has to live in pcu — the toolkit cannot add `[skip ci]` on its own. The toolkit's `update_prlog` job will opt in by default (skip the redundant run; re-enable only when necessary).

## Behaviour

- Default **off** — no change for existing callers or other subcommands.
- Only affects the `pr` command's commit message.

## Tests

Unit tests assert the resolved `commit_message` with and without `--skip-ci`. Full suite + cli_tests, fmt, clippy, audit all clean.