### PR TITLE
chore: add msrv verify recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,6 +34,18 @@ unit-tests:
 audit:
     cargo deny check advisories bans licenses sources
 
+# verify the documented MSRV (rust-version) still builds with the locked deps.
+# CI's "minimum" build uses the earliest rolling toolchain, which is typically
+# newer than the documented MSRV, so it does NOT validate the true MSRV — run
+# this locally on every change (especially when Cargo.lock changes).
+msrv:
+    cargo msrv verify --manifest-path crates/pcu/Cargo.toml
+
+# discover the true minimum supported rust-version (bisects; run when a dep bump
+# breaks `just msrv`, then bump rust-version + CI min_rust_version + README badge).
+msrv-find:
+    cargo msrv find --manifest-path crates/pcu/Cargo.toml
+
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:
     cargo +nightly fmt --all -- --config-path rustfmt-nightly.toml


### PR DESCRIPTION
## Summary

Adds `just msrv` (and `just msrv-find`) so the documented MSRV is validated **locally** on every change.

```
msrv:       cargo msrv verify --manifest-path crates/pcu/Cargo.toml
msrv-find:  cargo msrv find   --manifest-path crates/pcu/Cargo.toml
```

## Why

CI's "minimum" build runs on the **earliest rolling toolchain** (current stable − 4, floored at 1.70). When the documented MSRV is *older* than that window, CI silently tests on a newer compiler and **never validates the true MSRV**. That's how the 1.88 → 1.89 drift (kdeets 0.1.30 / smol_str 0.3.6 now require 1.89) went unnoticed until `cargo +1.88 check` was run by hand.

`cargo msrv verify` builds the crate at the declared `rust-version` against the locked deps — the source of truth for MSRV. Kept **local** (cargo-msrv on the workstation) rather than in the container, to avoid baking aging Rust toolchains into the image.

## Process

- Run `just msrv` pre-PR on any Rust change (added to the global pre-PR checklist).
- When a dep bump breaks it, run `just msrv-find`, then bump `rust-version` + CI `min_rust_version` + README badge to the discovered minimum and re-verify.

## Verification

`cargo msrv verify` confirms **Rust 1.89.0 is compatible** on current `main`. `just --list` shows the recipes; `just --fmt --check` passes.