### PR TITLE
fix(deps): update config to 0.15.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
 dependencies = [
  "pathdiff",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.45"
 clap = "4.6.1"
 clap-verbosity-flag = "3.0.4"
 color-eyre = "0.6.5"
-config = {version = "0.15.22", features = ["toml"], default-features = false}
+config = {version = "0.15.24", features = ["toml"], default-features = false}
 env_logger = "0.11.10"
 gen-bsky = { path = "crates/gen-bsky", version = "0.1.24" }
 gen-linkedin = { path = "crates/gen-linkedin", version = "0.1.17" }


### PR DESCRIPTION
Manual update of the `config` crate **0.15.22 → 0.15.24**.

Renovate's automated PR was edited/blocked (Dependency Dashboard #156 → "PR Edited (Blocked)"), so it can't self-update. Doing it by hand to unblock the release.

Patch bump, no API changes. Verified on this branch:
- `cargo fmt --all --check` ✅
- `cargo clippy --all --tests --all-features -- -D warnings` ✅
- full test suite (197 tests) ✅
- `cargo audit` clean (naked probe shows only the two already-accepted advisories — RUSTSEC-2023-0071, RUSTSEC-2026-0173; neither stale) ✅
- `cargo msrv verify` — 1.89 still compatible ✅

Closes #979.