### PR TITLE
fix: enable git2 https+ssh features (TLS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
  "url",
 ]
 
@@ -2670,7 +2672,9 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -2697,6 +2701,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2911,7 +2929,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3255,6 +3273,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -4302,7 +4326,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,11 @@ config = {version = "0.15.24", features = ["toml"], default-features = false}
 env_logger = "0.11.10"
 gen-bsky = { path = "crates/gen-bsky", version = "0.1.25" }
 gen-linkedin = { path = "crates/gen-linkedin", version = "0.1.18" }
-git2 = "0.21.0"
+# git2 0.21 changed its default features to `[]` (0.20 defaulted to
+# ["ssh", "https"]). Without `https`, libgit2 is built with no TLS backend and
+# every HTTPS git op fails at runtime ("there is no TLS stream available").
+# Enable them explicitly; `ssh` keeps SSH remotes working too.
+git2 = { version = "0.21.0", features = ["ssh", "https"] }
 git2_credentials = "0.16.0"
 gql_client = "1.1.0"
 bytes = "1.11.1"

--- a/crates/pcu/src/lib.rs
+++ b/crates/pcu/src/lib.rs
@@ -15,3 +15,34 @@ pub use ops::{
 };
 pub use pr_title::PrTitle;
 pub use workspace::{Package, Workspace};
+
+#[cfg(test)]
+mod git2_build_features {
+    //! Guards the linked libgit2 build features. `git2` 0.21 changed its
+    //! default features to `[]` (0.20 defaulted to `["ssh", "https"]`), so a
+    //! bare `git2 = "0.21"` builds libgit2 WITHOUT a TLS backend — any HTTPS
+    //! git operation then fails at runtime with
+    //! `there is no TLS stream available; class=Ssl (16)` (pcu checkout/pr/push).
+    //! These tests fail fast at build/test time if the features regress again.
+
+    #[test]
+    fn libgit2_has_https_support() {
+        assert!(
+            git2::Version::get().https(),
+            "linked libgit2 has no HTTPS/TLS backend — pcu's HTTPS git operations \
+             (checkout/pr/push) will fail with 'there is no TLS stream available'. \
+             Ensure the `git2` dependency enables the `https` feature (git2 0.21 \
+             dropped it from the default feature set)."
+        );
+    }
+
+    #[test]
+    fn libgit2_has_ssh_support() {
+        assert!(
+            git2::Version::get().ssh(),
+            "linked libgit2 has no SSH backend — SSH git remotes will fail. \
+             Ensure the `git2` dependency enables the `ssh` feature (git2 0.21 \
+             dropped it from the default feature set)."
+        );
+    }
+}


### PR DESCRIPTION
## Problem

pcu **0.6.23** fails every HTTPS git operation at runtime:

```
Git2 says: there is no TLS stream available; class=Ssl (16)
  at pcu-0.6.23/src/bin/main.rs:74
```

Observed breaking `update_prlog` (post-merge `pcu checkout`) on the rebuilt CI container; also affects `pcu pr` / `pcu push` over HTTPS.

## Root cause

**git2 0.21 changed its default features to `[]`** (0.20 defaulted to `["ssh", "https"]`). pcu has always used a bare `git2 = "0.x"`, relying on those defaults. After the 0.20.4 → 0.21.0 bump, libgit2 is built with **no `https` feature → no TLS backend**, hence the error. 0.6.19 (git2 0.20.4) worked; 0.6.23 (git2 0.21.0) doesn't.

## Fix

```toml
git2 = { version = "0.21.0", features = ["ssh", "https"] }
```

- `https` restores the TLS backend (pulls openssl-sys/openssl-probe).
- `ssh` keeps SSH remotes working.

## Regression test

Added `git2_build_features` unit tests asserting `git2::Version::get().https()` and `.ssh()` (these query libgit2's compiled-in features). **RED** without the features (reproduces the exact production failure), **GREEN** with them — so a future default-feature regression fails at test time, not in CI/production.

## Verification

fmt, clippy, full suite (199 tests incl. the 2 new), `cargo msrv verify` (still 1.89), and `cargo audit` (no new advisories from libssh2-sys/openssl-probe) all pass.

⚠️ Needs a **0.6.24** release + container re-bump to unbreak the CI chain.