### PR TITLE
test: lock ambient-client commit contract; drop stale advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,13 +18,6 @@ ignore = [
     # decryption oracle) cannot be triggered. Remove when sigstore updates rsa.
     "RUSTSEC-2023-0071",
 
-    # RUSTSEC-2024-0370: proc-macro-error 1.0.4 — unmaintained crate.
-    # Fix attempted: no alternative until sigstore/json-syntax migrate away from
-    # locspan-derive. Transitive: sigstore → json-syntax → locspan-derive →
-    # proc-macro-error. Unmaintained ≠ vulnerable; no known CVE.
-    # Remove when sigstore updates its syntax-parsing dependencies.
-    "RUSTSEC-2024-0370",
-
     # RUSTSEC-2026-0173: proc-macro-error2 2.0.1 — unmaintained (2026-06-07).
     # The proc-macro-error2 repo is ARCHIVED, so it will never be patched.
     # Fix attempted: no fixed upstream exists. Remaining transitive path:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,7 +835,7 @@ workflows:
               only:
                 - main
                 - /pull\/[0-9]+/
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370 RUSTSEC-2026-0173"
+          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2026-0173"
       - toolkit/security:
           name: security with sonarcloud
           context: SonarCloud
@@ -844,6 +844,6 @@ workflows:
               ignore:
                 - /pull\/[0-9]+/
                 - main
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2024-0370 RUSTSEC-2026-0173"
+          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2026-0173"
 
 

--- a/crates/pcu/src/ops/git_ops.rs
+++ b/crates/pcu/src/ops/git_ops.rs
@@ -1367,6 +1367,41 @@ mod tests {
         );
     }
 
+    /// Contract: the **ambient** client (`new_local_at`, empty `github_token`,
+    /// dummy API stubs — no GitHub auth) can stage AND commit a change with no
+    /// network and no credentials. This is the contract the auto-record push
+    /// redesign relies on: the binary commits via pcu using only the ambient
+    /// environment, and a separate job performs the push. A regression here
+    /// (e.g. a future refactor coupling commit to the GitHub API) would silently
+    /// break auto-record, so it is locked explicitly.
+    #[test]
+    fn ambient_client_commits_staged_changes_without_auth() {
+        let (dir, client) = make_test_client();
+        std::fs::write(dir.path().join("regenerated.yml"), "orb: source\n").unwrap();
+        client.stage_paths(&[Path::new("regenerated.yml")]).unwrap();
+
+        // Identity is supplied explicitly so the commit does not depend on the
+        // temp repo's (absent) user.name/user.email git config.
+        let sign = SignConfig::new(Sign::None).with_identity("Bot", "bot@example.com");
+        client
+            .commit_staged(sign, "chore: regenerate orb", "", None)
+            .expect("ambient client must commit staged changes without GitHub auth");
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        // The subject is preserved; pcu may append a DCO sign-off trailer.
+        assert!(
+            head.message().unwrap().starts_with("chore: regenerate orb"),
+            "unexpected commit message: {:?}",
+            head.message()
+        );
+        assert_eq!(
+            head.parent_count(),
+            1,
+            "the commit must build on the init commit (HEAD advanced)"
+        );
+    }
+
     #[test]
     fn stage_paths_skips_nonexistent_path() {
         let (_dir, client) = make_test_client();

--- a/deny.toml
+++ b/deny.toml
@@ -14,9 +14,6 @@ ignore = [
     # pcu uses sigstore only for signing CI attestations (not for decryption
     # operations), so the risk is low. Remove when sigstore updates rsa.
     { id = "RUSTSEC-2023-0071", reason = "transitive via sigstore 0.13.0; no fix available upstream" },
-    # proc-macro-error 1.0.4: unmaintained. Transitive via
-    # sigstore 0.13.0 → json-syntax → locspan-derive. No alternative upstream.
-    { id = "RUSTSEC-2024-0370", reason = "transitive via sigstore 0.13.0; no fix available upstream" },
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
## Summary

Two small, independent changes (separate commits):

### 1. `test:` lock the ambient-client commit-without-auth contract

Part of the gen-circleci-orb auto-record **push redesign**: the binary will commit the regenerated orb via pcu using only the *ambient* environment authorization (no GitHub credentials of its own), and a separate end-of-workflow job performs the push.

That ambient client already exists — `Client::new_local()` / `new_local_at()`: it opens the cwd repo, derives owner/repo from the remote, sets `github_token = ""`, and builds dummy unauthenticated API stubs. Local git ops (`stage_paths`, `commit_staged`) work with no network/auth; GitHub-auth methods fail unless the environment supplies creds.

This adds `ambient_client_commits_staged_changes_without_auth`, which stages a file and `commit_staged`s it through the ambient client and asserts HEAD advanced — **locking the stage+commit contract** so a future refactor that couples committing to the GitHub API can't silently break auto-record. (The test also documents that `commit_staged` appends a DCO `Signed-off-by:` trailer by default.)

No production code changes — `new_local()` already provides everything the redesign needs.

### 2. `chore:` drop the now-stale `RUSTSEC-2024-0370` ignore

`proc-macro-error` v1 is no longer in `Cargo.lock` (the tree now uses `proc-macro-error2`), so `RUSTSEC-2024-0370` never fires. A naked `cargo audit` (run with no config, against the locked deps) no longer reports it, yet it was still suppressed in three places. Removed from `.cargo/audit.toml`, `deny.toml`, and the CI `ignore_advisories` so the suppression lists reflect reality. This also clears a latent cargo-deny "unmatched advisory" condition.

The other two suppressions (`RUSTSEC-2023-0071` rsa, `RUSTSEC-2026-0173` proc-macro-error2) **do** still appear in the naked audit — they remain, untouched.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --all --tests --all-features -- -D warnings` — clean
- `cargo test -p pcu --all-features` — **202 passed** (incl. the new test and pcu doctests)
- `cargo audit` (configured) — clean; `cargo deny check advisories` — `advisories ok`
- MSRV: unaffected (no `Cargo.toml`/`Cargo.lock` change)

(Note: `cargo test --workspace --all-features` surfaces pre-existing **gen-bsky doctest** failures unrelated to this change — confirmed identical with this change stashed; CI's nextest does not run doctests. Flagged separately, out of scope here.)
