### PR TITLE
fix: include docs/lib.md in gen-bsky package

### DIFF
--- a/crates/gen-bsky/Cargo.toml
+++ b/crates/gen-bsky/Cargo.toml
@@ -13,6 +13,10 @@ include = [
     "**/*.rs",
     "**/*.mmd",
     "doc/mermaid-init.html",
+    # docsrs include_str! target (src/lib.rs `#![cfg_attr(docsrs, doc = include_str!("../docs/lib.md"))]`).
+    # The `include` allowlist omits it otherwise, so docs.rs (which builds with
+    # --cfg docsrs from the published tarball) fails with "couldn't read docs/lib.md".
+    "docs/lib.md",
     "Cargo.toml",
     "README.md",
     "LICENSE-MIT",


### PR DESCRIPTION
## Problem

docs.rs fails to build `gen-bsky` (the crate has no rendered docs on docs.rs):

```
error: couldn't read `src/../docs/lib.md`: No such file or directory (os error 2)
 --> src/lib.rs:7:27
   | #![cfg_attr(docsrs, doc = include_str!("../docs/lib.md"))]
error: could not document `gen-bsky`
```

## Root cause

docs.rs builds with `--cfg docsrs`, which activates the `cfg_attr` in `src/lib.rs` that `include_str!`s `docs/lib.md`. The file exists in the repo, **but the `Cargo.toml` `include` allowlist** (`**/*.rs`, `**/*.mmd`, `doc/mermaid-init.html`, `Cargo.toml`, `README.md`, `LICENSE-*`) **did not match `docs/lib.md`**, so it was omitted from the published crate tarball. docs.rs builds from that tarball → the include target is missing → hard error.

This never surfaces in normal builds (the `cfg_attr` is inactive without `--cfg docsrs`) nor in `cargo package`'s verify step (it builds, doesn't rustdoc with docsrs).

## Fix

Add `docs/lib.md` to `include`. It's the only `include_str!` target in the crate; `docs/readme/{head,tail}.md` are README-generation sources (not `include_str!`'d) and remain excluded so the tarball stays lean.

## Verification

- `cargo package --list -p gen-bsky` now lists `docs/lib.md` (previously absent — only `README.md` was).
- **docs.rs reproduction:** extracted the packaged `.crate` and ran `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --lib --all-features` in it — **succeeds** ("Documenting gen-bsky → Finished"), where it previously failed with `couldn't read docs/lib.md`.
- `cargo clippy --all --tests --all-features -- -D warnings` — clean; `cargo test -p gen-bsky` — 367 pass; `cargo fmt --all --check` — clean.
- Packaging-metadata-only change: audit/MSRV unaffected.

docs.rs will rebuild successfully on the next `gen-bsky` release.
