### PR TITLE
fix: repair gen-bsky doctests (21 failing)

### DIFF
--- a/crates/gen-bsky/src/draft.rs
+++ b/crates/gen-bsky/src/draft.rs
@@ -76,7 +76,6 @@ pub enum DraftError {
 /// # use std::path::PathBuf;
 /// #
 /// # use url::Url;
-/// # use toml::value::Datetime;
 /// #
 /// # use gen_bsky::{Draft, DraftError};
 /// #
@@ -84,13 +83,7 @@ pub enum DraftError {
 /// # async fn main() -> Result<(), DraftError> {
 ///     let base_url = Url::parse("https://www.example.com/")?;
 ///     let paths = vec!["content/blog".to_string()];
-///     let date = Datetime {
-///                   date: Some(toml::value::Date{
-///                               year: 2025,
-///                               month: 8,
-///                               day: 4}),
-///                   time: None,
-///                   offset: None};
+///     let date = "2025-08-04";
 ///     let allow_draft = false;
 ///
 ///     let mut posts = get_post_drafts(
@@ -108,12 +101,9 @@ pub enum DraftError {
 ///  async fn get_post_drafts(
 ///             base_url: Url,
 ///             paths: Vec<String>,
-///             date: Datetime,
+///             date: &str,
 ///             allow_draft: bool) -> Result<Draft, DraftError>
 /// {
-///     let post_store = PathBuf::new().join("bluesky_post_store");
-///     let referrer_store = PathBuf::new().join("static").join("s");
-///
 ///     let mut builder = Draft::builder(base_url, None);
 ///    
 ///     // Add the paths specified at the command line.
@@ -123,8 +113,6 @@ pub enum DraftError {
 ///    
 ///     // Set the filters for blog posts
 ///     builder
-///     .with_post_store(post_store)?
-///     .with_referrer_store(referrer_store)?
 ///     .with_minimum_date(date)?
 ///     .with_allow_draft(allow_draft);
 ///    

--- a/crates/gen-bsky/src/draft/blog_post.rs
+++ b/crates/gen-bsky/src/draft/blog_post.rs
@@ -48,7 +48,7 @@
 //!
 //! ### Constructor
 //!
-//! ```rust
+//! ```rust,ignore
 //! pub fn new(
 //!     blog_path: &PathBuf,
 //!     min_date: Datetime,
@@ -71,14 +71,14 @@
 //!
 //! ### Accessor Methods
 //!
-//! ```rust
+//! ```rust,ignore
 //! pub fn title(&self) -> &str
 //! ```
 //! Returns the post title from front matter.
 //!
 //! ### Core Functionality
 //!
-//! ```rust
+//! ```rust,ignore
 //! pub async fn get_bluesky_record(&self) -> Result<RecordData, BlogPostError>
 //! ```
 //!
@@ -90,7 +90,7 @@
 //! - Validates character and grapheme limits (300 max)
 //! - Creates proper Bluesky API record format
 //!
-//! ```rust
+//! ```rust,ignore
 //! pub fn write_referrer_file_to(
 //!     &mut self,
 //!     store_dir: &Path,
@@ -104,7 +104,7 @@
 //! - `store_dir` - Directory to write the redirect file
 //! - `base_url` - Base URL for constructing the short link
 //!
-//! ```rust
+//! ```rust,ignore
 //! pub async fn write_bluesky_record_to(&mut self, store_dir: &Path) -> Result<(), BlogPostError>
 //! ```
 //!
@@ -121,7 +121,7 @@
 //! ### Post Text Format
 //!
 //! The generated Bluesky post follows this format:
-//! ```
+//! ```text
 //! {
 //!     title
 //! }
@@ -171,7 +171,7 @@
 //!
 //! ## Usage Example
 //!
-//! ```rust
+//! ```rust,ignore
 //! use std::path::PathBuf;
 //!
 //! use toml::value::Datetime;

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/bluesky.rs
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/bluesky.rs
@@ -9,7 +9,7 @@
 ///
 /// ## Struct Definition
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 /// pub(crate) struct Bluesky {
 ///     description: Option<String>,
@@ -227,13 +227,13 @@
 /// ### Construction Methods
 ///
 /// #### Default Construction
-/// ```rust
+/// ```rust,ignore
 /// let bluesky = Bluesky::default();
 /// // Both description and tags are None
 /// ```
 ///
 /// #### Field-by-Field Construction
-/// ```rust
+/// ```rust,ignore
 /// let bluesky = Bluesky {
 ///     description: Some("My post description".to_string()),
 ///     tags: Some(vec![

--- a/crates/gen-bsky/src/draft/blog_post/front_matter/extra.rs
+++ b/crates/gen-bsky/src/draft/blog_post/front_matter/extra.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Rust Usage
 ///
-/// ```rust
+/// ```rust,ignore
 /// use your_crate::Extra;
 ///
 /// // Create an empty Extra struct
@@ -70,7 +70,7 @@ impl Extra {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// use your_crate::Extra;
     ///
     /// let extra = Extra::default();

--- a/crates/gen-bsky/src/draft/draft_builder.rs
+++ b/crates/gen-bsky/src/draft/draft_builder.rs
@@ -101,6 +101,7 @@ impl DraftBuilder {
     /// #         Ok(self)
     /// #     }
     /// # }
+    /// # fn gdb() -> PathBuilder { PathBuilder::new() }
     /// let mut builder = gdb();
     ///
     /// // Add a file using a string literal
@@ -111,7 +112,6 @@ impl DraftBuilder {
     /// builder.add_path_or_file(dir)?;
     ///
     /// // Add using a PathBuf
-    /// use std::path::PathBuf;
     /// let path = PathBuf::from("../assets/images");
     /// builder.add_path_or_file(path)?;
     ///
@@ -144,8 +144,9 @@ impl DraftBuilder {
     /// #         self.path_or_file.push(path_or_file.into());
     /// #         Ok(self)
     /// #     }
-    /// #     pub fn build(self) -> Vec<PathBuf> { self.path_or_file }
+    /// #     pub fn build(&self) -> Vec<PathBuf> { self.path_or_file.clone() }
     /// # }
+    /// # fn gdb() -> PathBuilder { PathBuilder::new() }
     /// let paths = gdb()
     ///     .add_path_or_file("src/")?
     ///     .add_path_or_file("tests/")?


### PR DESCRIPTION
## Problem

All 21 gen-bsky doctests fail to compile, but they never ran in CI — nextest skips doctests and the doc job only builds HTML (see digital-prstv/circleci-toolkit#481). So the rot was latent; surfaced while running the full local suite.

Categories of breakage:
- **Signature/template display blocks** fenced as runnable `rust` (e.g. `pub fn title(&self) -> &str`, the post-format template) — not compilable, and `BlogPost` is `pub(super)` so a doctest can't reach it.
- **Internal-type examples** referencing `pub(crate)` `Bluesky`/`Extra` (and a `use your_crate::…` placeholder) — unreachable from a doctest, which compiles as an external crate.
- **`add_path_or_file` examples** called a `gdb()` helper that was never defined in the snippet, plus a mock `build(self)` that didn't compose with the `&mut self` chain and a duplicate `PathBuf` import.
- **`Draft` example** drifted from the current builder API.

## Fix

- `blog_post.rs`: signature blocks → `rust,ignore`; post-format template → `text`; the internal usage example → `rust,ignore`.
- `bluesky.rs` / `extra.rs`: `pub(crate)`/placeholder examples → `rust,ignore` (matches the author's existing `rust ignore` block).
- `draft_builder.rs`: add the hidden `gdb()` helper the examples call; mock `build` takes `&self`; drop the duplicate `PathBuf` import. These now **compile and run**.
- `draft.rs`: update the public `Draft` example to the current API — `with_minimum_date` takes `&str`; `with_post_store`/`with_referrer_store` are gone (stores are passed to `write_referrers`/`write_bluesky_posts`). Now **compiles and runs** (`should_panic`).

Public-API examples are made real (compile-checked); examples that reference crate-private types — which a doctest fundamentally cannot import — are marked non-running rather than faked.

## Verification

`cargo test --all --all-features` (incl. doctests) — **0 failures** (was 21). `cargo fmt --all --check`, `cargo clippy --all --tests --all-features -- -D warnings`, `cargo audit` — all clean.

Follow-up to make CI actually run doctests: digital-prstv/circleci-toolkit#481.
