### PR TITLE
fix: pcu owns a safe, well-named release push

### DIFF
--- a/crates/pcu/src/cli/release.rs
+++ b/crates/pcu/src/cli/release.rs
@@ -286,6 +286,34 @@ fn write_to_bash_env(key: &str, value: &str) -> Result<(), Error> {
     Ok(())
 }
 
+/// Commit subject for the prlog update that accompanies a release.
+///
+/// Distinct from the routine post-merge `chore: update prlog for pr`: this
+/// commit also carries the version tag, so it must be identifiable as a release
+/// on the default branch (and version-stamped for traceability) rather than
+/// masquerading as a generic prlog update.
+fn release_prlog_commit_message(version: &str) -> String {
+    format!("chore: update prlog for release {version}")
+}
+
+#[cfg(test)]
+mod release_message_tests {
+    use super::*;
+
+    #[test]
+    fn release_prlog_message_names_the_release_not_a_pr() {
+        let m = release_prlog_commit_message("1.2.3");
+        assert!(
+            m.contains("release") && m.contains("1.2.3"),
+            "release prlog commit must name the release + version: {m}"
+        );
+        assert!(
+            !m.contains("for pr"),
+            "must not masquerade as a routine post-merge pr prlog update: {m}"
+        );
+    }
+}
+
 #[derive(Debug, Parser, Clone)]
 pub struct Release {
     /// Update the prlog by renaming the unreleased section with the version
@@ -435,10 +463,10 @@ impl Release {
                 print_prlog(client.prlog_as_str(), client.line_limit())
             );
 
-            let commit_message = "chore: update prlog for pr";
+            let commit_message = release_prlog_commit_message(&version);
 
             client
-                .commit_changed_files(sign_config, commit_message, &self.prefix, Some(&version))
+                .commit_changed_files(sign_config, &commit_message, &self.prefix, Some(&version))
                 .await?;
 
             log::info!("Push the commit");

--- a/crates/pcu/src/cli/release.rs
+++ b/crates/pcu/src/cli/release.rs
@@ -132,106 +132,6 @@ where
     Ok(EnsureOutcome::Created)
 }
 
-#[cfg(test)]
-mod ensure_release_tests {
-    use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    #[tokio::test]
-    async fn creates_release_when_tag_present_and_release_absent() {
-        let made = AtomicU32::new(0);
-        let outcome = ensure_release_for_tag(
-            "crate-v1.0.0",
-            || async { true },
-            || async { Ok(false) },
-            || async {
-                made.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .await;
-        assert_eq!(outcome.unwrap(), EnsureOutcome::Created);
-        assert_eq!(
-            made.load(Ordering::SeqCst),
-            1,
-            "make_release must be called exactly once"
-        );
-    }
-
-    #[tokio::test]
-    async fn errors_when_make_release_fails() {
-        let r = ensure_release_for_tag(
-            "crate-v1.0.0",
-            || async { true },
-            || async { Ok(false) },
-            || async { Err(Error::GitError("boom".into())) },
-        )
-        .await;
-        assert!(r.is_err(), "a failed creation must surface as an error");
-    }
-
-    #[tokio::test]
-    async fn errors_when_release_existence_undetermined() {
-        // The core fix: a non-conclusive existence check must NOT become a
-        // silent Ok-skip (the 0.0.53 stranding). It must error and not create.
-        let made = AtomicU32::new(0);
-        let r = ensure_release_for_tag(
-            "crate-v1.0.0",
-            || async { true },
-            || async { Err(Error::GitError("api 500".into())) },
-            || async {
-                made.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .await;
-        assert!(r.is_err(), "undetermined existence must error, not skip");
-        assert_eq!(
-            made.load(Ordering::SeqCst),
-            0,
-            "must not blindly create when existence is undetermined"
-        );
-    }
-
-    #[tokio::test]
-    async fn skips_when_release_already_present() {
-        let made = AtomicU32::new(0);
-        let outcome = ensure_release_for_tag(
-            "crate-v1.0.0",
-            || async { true },
-            || async { Ok(true) },
-            || async {
-                made.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .await;
-        assert_eq!(outcome.unwrap(), EnsureOutcome::AlreadyPresent);
-        assert_eq!(
-            made.load(Ordering::SeqCst),
-            0,
-            "must not re-create an existing release"
-        );
-    }
-
-    #[tokio::test]
-    async fn reports_tag_absent_without_error() {
-        let made = AtomicU32::new(0);
-        let outcome = ensure_release_for_tag(
-            "crate-v1.0.0",
-            || async { false },
-            || async { Ok(false) },
-            || async {
-                made.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .await;
-        assert_eq!(outcome.unwrap(), EnsureOutcome::TagAbsent);
-        assert_eq!(made.load(Ordering::SeqCst), 0);
-    }
-}
-
 /// Create a GitHub release for `<prefix><version>` when needed.
 ///
 /// Idempotent: if the git tag is absent, logs an error and returns `Ok`.
@@ -294,24 +194,6 @@ fn write_to_bash_env(key: &str, value: &str) -> Result<(), Error> {
 /// masquerading as a generic prlog update.
 fn release_prlog_commit_message(version: &str) -> String {
     format!("chore: update prlog for release {version}")
-}
-
-#[cfg(test)]
-mod release_message_tests {
-    use super::*;
-
-    #[test]
-    fn release_prlog_message_names_the_release_not_a_pr() {
-        let m = release_prlog_commit_message("1.2.3");
-        assert!(
-            m.contains("release") && m.contains("1.2.3"),
-            "release prlog commit must name the release + version: {m}"
-        );
-        assert!(
-            !m.contains("for pr"),
-            "must not masquerade as a routine post-merge pr prlog update: {m}"
-        );
-    }
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -1624,5 +1506,123 @@ mod upload_retry_tests {
         .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "release");
+    }
+}
+
+#[cfg(test)]
+mod ensure_release_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn creates_release_when_tag_present_and_release_absent() {
+        let made = AtomicU32::new(0);
+        let outcome = ensure_release_for_tag(
+            "crate-v1.0.0",
+            || async { true },
+            || async { Ok(false) },
+            || async {
+                made.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome.unwrap(), EnsureOutcome::Created);
+        assert_eq!(
+            made.load(Ordering::SeqCst),
+            1,
+            "make_release must be called exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_when_make_release_fails() {
+        let r = ensure_release_for_tag(
+            "crate-v1.0.0",
+            || async { true },
+            || async { Ok(false) },
+            || async { Err(Error::GitError("boom".into())) },
+        )
+        .await;
+        assert!(r.is_err(), "a failed creation must surface as an error");
+    }
+
+    #[tokio::test]
+    async fn errors_when_release_existence_undetermined() {
+        // The core fix: a non-conclusive existence check must NOT become a
+        // silent Ok-skip (the 0.0.53 stranding). It must error and not create.
+        let made = AtomicU32::new(0);
+        let r = ensure_release_for_tag(
+            "crate-v1.0.0",
+            || async { true },
+            || async { Err(Error::GitError("api 500".into())) },
+            || async {
+                made.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await;
+        assert!(r.is_err(), "undetermined existence must error, not skip");
+        assert_eq!(
+            made.load(Ordering::SeqCst),
+            0,
+            "must not blindly create when existence is undetermined"
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_when_release_already_present() {
+        let made = AtomicU32::new(0);
+        let outcome = ensure_release_for_tag(
+            "crate-v1.0.0",
+            || async { true },
+            || async { Ok(true) },
+            || async {
+                made.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome.unwrap(), EnsureOutcome::AlreadyPresent);
+        assert_eq!(
+            made.load(Ordering::SeqCst),
+            0,
+            "must not re-create an existing release"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_tag_absent_without_error() {
+        let made = AtomicU32::new(0);
+        let outcome = ensure_release_for_tag(
+            "crate-v1.0.0",
+            || async { false },
+            || async { Ok(false) },
+            || async {
+                made.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome.unwrap(), EnsureOutcome::TagAbsent);
+        assert_eq!(made.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[cfg(test)]
+mod release_message_tests {
+    use super::*;
+
+    #[test]
+    fn release_prlog_message_names_the_release_not_a_pr() {
+        let m = release_prlog_commit_message("1.2.3");
+        assert!(
+            m.contains("release") && m.contains("1.2.3"),
+            "release prlog commit must name the release + version: {m}"
+        );
+        assert!(
+            !m.contains("for pr"),
+            "must not masquerade as a routine post-merge pr prlog update: {m}"
+        );
     }
 }

--- a/crates/pcu/src/ops/git_ops.rs
+++ b/crates/pcu/src/ops/git_ops.rs
@@ -666,6 +666,19 @@ impl GitOps for Client {
         _bot_user_name: &str,
     ) -> Result<(), Error> {
         log::trace!("version: {version:?} and no_push: {no_push}");
+
+        // Guarantee the push is a fast-forward before touching the remote: refresh
+        // the target branch and refuse clearly if it has advanced beyond our local
+        // history. pcu owns this assurance so a moved `main` produces an actionable
+        // error here, not git2's opaque NotFastForward at push time (or a silently
+        // swallowed push). The release_crate job refreshes its base before building
+        // the commit/tag, so in the normal case `behind` is 0 and this is a no-op.
+        if !no_push {
+            let branch = self.branch_or_main().to_string();
+            self.fetch_branch(&branch)?;
+            ensure_fast_forward(&branch, self.branch_status()?.behind)?;
+        }
+
         let mut remote = self.git_repo.find_remote("origin")?;
         let remote_url = remote.url().unwrap_or("<unknown>").to_string();
 
@@ -887,6 +900,21 @@ impl GitOps for Client {
 
         Ok(BranchReport { ahead, behind })
     }
+}
+
+/// Refuse to push `branch` when the local branch is `behind` its remote — the
+/// push would not be a fast-forward. Converts git2's opaque `NotFastForward`
+/// into a clear, actionable message naming the cause (the remote moved under
+/// us), rather than letting the raw error surface or a swallowed push hide it.
+fn ensure_fast_forward(branch: &str, behind: usize) -> Result<(), Error> {
+    if behind > 0 {
+        return Err(Error::GitError(format!(
+            "Refusing to push '{branch}': origin/{branch} has advanced {behind} commit(s) not in \
+             the local history, so the push would not be a fast-forward. Re-run the release \
+             pipeline so it rebuilds on the current HEAD."
+        )));
+    }
+    Ok(())
 }
 
 fn make_credential(
@@ -1122,6 +1150,26 @@ mod tests {
     use super::*;
     use git2::Signature;
     use rstest::rstest;
+
+    #[test]
+    fn ensure_fast_forward_refuses_when_behind() {
+        let r = ensure_fast_forward("main", 2);
+        assert!(r.is_err(), "must refuse a non-fast-forward push");
+        let msg = r.unwrap_err().to_string();
+        assert!(msg.contains("main"), "error must name the branch: {msg}");
+        assert!(
+            msg.to_lowercase().contains("fast-forward"),
+            "error must explain the cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn ensure_fast_forward_ok_when_current() {
+        assert!(
+            ensure_fast_forward("main", 0).is_ok(),
+            "a fast-forwardable push is allowed"
+        );
+    }
 
     #[test]
     fn test_ssh_to_https_url_scp_format() {


### PR DESCRIPTION
Two release-push lazy practices from the gen-circleci-orb 0.0.53 review, unwound. Follows #996 (the `ensure_github_release` silent-Ok fix).

## B — pcu owns the fast-forward guarantee

`push_commit` ended in `remote.push(...)?`, so when `main` moved under a release — our **own** multi-push flow racing, not a foreign merge — it surfaced git2's opaque `NotFastForward` (and, per #825, a `pr --push` can swallow it entirely).

Now pcu owns the assurance: before touching the remote it **fetches the target branch** and, via `ensure_fast_forward`, **refuses clearly** when the local branch is behind:

> `Refusing to push 'main': origin/main has advanced N commit(s) not in the local history, so the push would not be a fast-forward. Re-run the release pipeline so it rebuilds on the current HEAD.`

Never the raw git2 error, never a silent swallow. It's a no-op in the normal case (`behind == 0`) — and the planned `release_crate` base-refresh (part D) keeps it that way, so this is the backstop, not the strategy. This is option (a) from the toolkit #467 discussion (not auto-rebase, which would have to re-sign the moved signed tag).

## C — the release commit stops masquerading as a prlog update

`release_version --update-prlog` hardcoded `"chore: update prlog for pr"` onto the commit that **also carries the version tag** — so on `main` the release commit was indistinguishable from a routine post-merge prlog chore. It now reads **`chore: update prlog for release <version>`** (via `release_prlog_commit_message`) — identifiable and version-stamped.

## Tests (RED/GREEN)

- `ensure_fast_forward`: refuses-when-behind (names branch + explains "fast-forward"), ok-when-current.
- `release_prlog_commit_message`: names the release + version, never "for pr".

`cargo test -p pcu` (210), `clippy --all-targets --all-features -D warnings`, `fmt --all --check`, `cargo audit`, `cargo msrv verify` (1.89.0) — all green.

Remaining: **D** — toolkit `release_crate` refreshes its base to `origin/main` HEAD before cargo-release (so B rarely has to refuse). One pcu release then carries #996 + this into the not-yet-released ci-container.
