### PR TITLE
feat: controllable ci-skip on the release prlog commit

### DIFF
--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -282,11 +282,44 @@ fn print_prlog(prlog_path: &str, mut line_limit: usize) -> String {
     output
 }
 
+/// Append the CI-skip marker to a commit message, but only on the default
+/// branch — on a feature/PR branch we want validation to run. Centralises the
+/// skip-ci decision shared by the PR-prlog and release-prlog commit paths, so
+/// "skip, or skip the skip" behaves identically wherever a release-flow commit
+/// is written to the default branch.
+pub(crate) fn with_skip_ci(message: &str, skip_ci: bool, on_default_branch: bool) -> String {
+    if skip_ci && on_default_branch {
+        format!("{message} [skip ci]")
+    } else {
+        message.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::SignConfig;
     use clap::Parser;
+
+    #[test]
+    fn with_skip_ci_appends_marker_only_on_default_branch() {
+        let marker = format!("chore: x {}", "[skip ci]");
+        assert_eq!(
+            with_skip_ci("chore: x", true, true),
+            marker,
+            "default branch + skip requested → marker appended"
+        );
+        assert_eq!(
+            with_skip_ci("chore: x", true, false),
+            "chore: x",
+            "PR/feature branch must validate — never skip there"
+        );
+        assert_eq!(
+            with_skip_ci("chore: x", false, true),
+            "chore: x",
+            "no skip requested → message unchanged"
+        );
+    }
 
     #[test]
     fn pr_config_commit_message_is_plain_regardless_of_skip_ci() {

--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -322,6 +322,50 @@ mod tests {
     }
 
     #[test]
+    fn release_skip_ci_flag_is_negatable() {
+        let skip = |args: &[&str]| -> bool {
+            match Cli::try_parse_from(args).unwrap().command {
+                Commands::Release(r) => r.skip_ci,
+                other => panic!("expected Release, got {other:?}"),
+            }
+        };
+        assert!(
+            !skip(&["pcu", "release", "version", "1.0.0"]),
+            "default: validate (do not skip)"
+        );
+        assert!(
+            skip(&["pcu", "release", "--skip-ci", "version", "1.0.0"]),
+            "--skip-ci skips"
+        );
+        assert!(
+            !skip(&["pcu", "release", "--no-skip-ci", "version", "1.0.0"]),
+            "--no-skip-ci validates explicitly"
+        );
+        assert!(
+            !skip(&[
+                "pcu",
+                "release",
+                "--skip-ci",
+                "--no-skip-ci",
+                "version",
+                "1.0.0"
+            ]),
+            "last flag wins: no-skip"
+        );
+        assert!(
+            skip(&[
+                "pcu",
+                "release",
+                "--no-skip-ci",
+                "--skip-ci",
+                "version",
+                "1.0.0"
+            ]),
+            "last flag wins: skip"
+        );
+    }
+
+    #[test]
     fn pr_config_commit_message_is_plain_regardless_of_skip_ci() {
         // The config layer never encodes `[skip ci]` — that is appended at
         // commit time only when on the default branch (see

--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -366,6 +366,32 @@ mod tests {
     }
 
     #[test]
+    fn pr_skip_ci_flag_is_negatable() {
+        // Kept symmetric with `release` so the ci-skip control is identical
+        // wherever it appears.
+        let skip = |args: &[&str]| -> bool {
+            match Cli::try_parse_from(args).unwrap().command {
+                Commands::Pr(p) => p.skip_ci,
+                other => panic!("expected Pr, got {other:?}"),
+            }
+        };
+        assert!(!skip(&["pcu", "pr"]), "default: validate (do not skip)");
+        assert!(skip(&["pcu", "pr", "--skip-ci"]), "--skip-ci skips");
+        assert!(
+            !skip(&["pcu", "pr", "--no-skip-ci"]),
+            "--no-skip-ci validates explicitly"
+        );
+        assert!(
+            !skip(&["pcu", "pr", "--skip-ci", "--no-skip-ci"]),
+            "last flag wins: no-skip"
+        );
+        assert!(
+            skip(&["pcu", "pr", "--no-skip-ci", "--skip-ci"]),
+            "last flag wins: skip"
+        );
+    }
+
+    #[test]
     fn pr_config_commit_message_is_plain_regardless_of_skip_ci() {
         // The config layer never encodes `[skip ci]` — that is appended at
         // commit time only when on the default branch (see
@@ -380,6 +406,7 @@ mod tests {
                 allow_push_fail: true,
                 allow_no_pull_request: true,
                 skip_ci,
+                no_skip_ci: false,
             });
             let settings = cmd.get_settings().unwrap();
             assert_eq!(

--- a/crates/pcu/src/cli/pull_request.rs
+++ b/crates/pcu/src/cli/pull_request.rs
@@ -181,15 +181,12 @@ impl Pr {
         client: Client,
         sign_config: SignConfig,
     ) -> Result<CIExit, Error> {
-        // Append `[skip ci]` only when committing the PRLOG update to the
+        // Append the CI-skip marker only when committing the PRLOG update to the
         // default branch (the post-merge update). On a PR branch we WANT
         // validation to run, so never skip CI there.
         let on_default_branch = client.branch_or_main() == client.default_branch.as_str();
-        let commit_message = if self.skip_ci && on_default_branch {
-            format!("{} [skip ci]", client.commit_message)
-        } else {
-            client.commit_message.clone()
-        };
+        let commit_message =
+            super::with_skip_ci(&client.commit_message, self.skip_ci, on_default_branch);
         client
             .commit_changed_files(sign_config, &commit_message, &self.prefix, None)
             .await?;

--- a/crates/pcu/src/cli/pull_request.rs
+++ b/crates/pcu/src/cli/pull_request.rs
@@ -34,11 +34,16 @@ pub struct Pr {
     /// request was found in CI environment.
     #[clap(long, default_value_t = true)]
     pub allow_no_pull_request: bool,
-    /// Append `[skip ci]` to the PRLOG commit message so the push to the default
-    /// branch does not trigger a redundant CI pipeline (e.g. the second
-    /// validation run after a "pr merged" PRLOG update).
-    #[clap(long, default_value_t = false)]
+    /// Skip CI on the PRLOG commit by appending the ci-avoidance marker so the
+    /// push to the default branch does not trigger a redundant CI pipeline (e.g.
+    /// the second validation run after a "pr merged" PRLOG update). Only takes
+    /// effect on the default branch.
+    #[clap(long, overrides_with = "no_skip_ci", default_value_t = false)]
     pub skip_ci: bool,
+    /// Explicitly do NOT skip CI on the PRLOG commit (the default). Provided so
+    /// "skip the skip" is stated explicitly. If both are given, the last wins.
+    #[clap(long = "no-skip-ci", action = clap::ArgAction::SetTrue, overrides_with = "skip_ci")]
+    pub no_skip_ci: bool,
 }
 
 impl Pr {
@@ -208,6 +213,7 @@ impl Pr {
             allow_push_fail: true,
             allow_no_pull_request: true,
             skip_ci,
+            no_skip_ci: false,
         }
     }
 

--- a/crates/pcu/src/cli/release.rs
+++ b/crates/pcu/src/cli/release.rs
@@ -7,6 +7,7 @@ async fn share_release_to_linkedin(prefix: &str, version: &str) -> Result<(), Er
         update_prlog: false,
         prefix: prefix.to_string(),
         linkedin_share: true,
+        skip_ci: false,
         mode: Mode::Version(crate::cli::release::mode::Version {
             version: version.to_string(),
         }),
@@ -208,6 +209,12 @@ pub struct Release {
     /// Also share this release to LinkedIn using configured credentials
     #[arg(long, default_value_t = false)]
     pub linkedin_share: bool,
+    /// Append the CI-skip marker to the prlog update commit when on the default
+    /// branch. Use it to skip the (redundant) validation of a release-flow
+    /// commit: the post-release prlog update in a single-crate repo, or each
+    /// crate release in a multi-crate repo. Off by default — "skip the skip".
+    #[arg(long, default_value_t = false)]
+    pub skip_ci: bool,
     #[command(subcommand)]
     pub mode: Mode,
 }
@@ -345,7 +352,12 @@ impl Release {
                 print_prlog(client.prlog_as_str(), client.line_limit())
             );
 
-            let commit_message = release_prlog_commit_message(&version);
+            let on_default_branch = client.branch_or_main() == client.default_branch.as_str();
+            let commit_message = super::with_skip_ci(
+                &release_prlog_commit_message(&version),
+                self.skip_ci,
+                on_default_branch,
+            );
 
             client
                 .commit_changed_files(sign_config, &commit_message, &self.prefix, Some(&version))

--- a/crates/pcu/src/cli/release.rs
+++ b/crates/pcu/src/cli/release.rs
@@ -8,6 +8,7 @@ async fn share_release_to_linkedin(prefix: &str, version: &str) -> Result<(), Er
         prefix: prefix.to_string(),
         linkedin_share: true,
         skip_ci: false,
+        no_skip_ci: false,
         mode: Mode::Version(crate::cli::release::mode::Version {
             version: version.to_string(),
         }),
@@ -209,12 +210,17 @@ pub struct Release {
     /// Also share this release to LinkedIn using configured credentials
     #[arg(long, default_value_t = false)]
     pub linkedin_share: bool,
-    /// Append the CI-skip marker to the prlog update commit when on the default
-    /// branch. Use it to skip the (redundant) validation of a release-flow
-    /// commit: the post-release prlog update in a single-crate repo, or each
-    /// crate release in a multi-crate repo. Off by default — "skip the skip".
-    #[arg(long, default_value_t = false)]
+    /// Skip CI on the prlog update commit by appending the ci-avoidance marker
+    /// (only takes effect on the default branch). Use it to drop the redundant
+    /// validation of a release-flow commit — the post-release prlog update in a
+    /// single-crate repo, or each crate release in a multi-crate repo.
+    #[arg(long, overrides_with = "no_skip_ci", default_value_t = false)]
     pub skip_ci: bool,
+    /// Explicitly do NOT skip CI on the prlog update commit (the default).
+    /// Provided so "skip the skip" is stated explicitly — e.g. the validating
+    /// final prlog of a multi-crate release. If both are given, the last wins.
+    #[arg(long = "no-skip-ci", action = clap::ArgAction::SetTrue, overrides_with = "skip_ci")]
+    pub no_skip_ci: bool,
     #[command(subcommand)]
     pub mode: Mode,
 }


### PR DESCRIPTION
Part of the release-flow hardening (follows #996, #997). One pcu release then carries all of it into the not-yet-released ci-container.

## Why

The release flow needs to control *which* release-flow commit triggers validation, and the polarity flips by repo type:

- **single-crate** (incl. orb-from-crate-tag): the crate release **validates** (its push triggers CI); the post-release prlog update carries the **ci-avoidance marker** — exactly like every post-merge prlog update.
- **multi-crate** (pcu): each crate release carries the marker; the **final prlog update validates once**, over the up-to-date released code.

So pcu must be able to **skip, and to skip the skip** — controllably, never hardcoded.

## Change

- New `--skip-ci` flag on `pcu release` (**default off**). When set, the prlog update commit (`release version --update-prlog`) gets the ci-avoidance marker — **gated to the default branch** (a feature/PR branch must always validate; the #984 lesson).
- Centralised the decision in `cli::with_skip_ci(message, skip_ci, on_default_branch)` and routed **both** the PR-prlog path (`pull_request.rs`) and the release-prlog path through it, deleting the duplicated inline logic — one tested place for the rule.

The toolkit wires the flag per step per repo type to realise the two flows above.

## Not in this PR (next)

- The **crate-release** commit's marker (the multi-crate "skip each crate release" half) — that commit is authored by cargo-release, so it needs a separate mechanism (cargo-release message vs a pcu amend). Tracked as follow-up.
- **Verification** of whether the marker on a commit suppresses a *tag*-triggered pipeline — to be settled on a **circleci-toolkit** release (orb-only, no Rust in the release mix, so a re-run without the marker is harmless if it does).

## Tests (RED/GREEN)

`with_skip_ci`: appends only on the default branch, never on a PR/feature branch, never when not requested. `cargo test -p pcu` (211), clippy, fmt, audit, `cargo msrv verify` (1.89.0) — all green.
