### PR TITLE
chore: drop redundant validation on cargo-release commits

### DIFF
--- a/crates/gen-bsky/release.toml
+++ b/crates/gen-bsky/release.toml
@@ -1,4 +1,4 @@
-pre-release-commit-message = "chore: Release gen-bsky v{{version}}"
+pre-release-commit-message = "chore: Release gen-bsky v{{version}} [skip ci]"
 tag-message = "{{tag_name}}"
 tag-name = "gen-bsky-v{{version}}"
 pre-release-hook = ["./release-hook.sh"]

--- a/crates/gen-linkedin/release.toml
+++ b/crates/gen-linkedin/release.toml
@@ -1,4 +1,4 @@
-pre-release-commit-message = "chore: Release gen-linkedin v{{version}}"
+pre-release-commit-message = "chore: Release gen-linkedin v{{version}} [skip ci]"
 tag-message = "{{tag_name}}"
 tag-name = "gen-linkedin-v{{version}}"
 pre-release-hook = ["./release-hook.sh"]

--- a/crates/pcu/release.toml
+++ b/crates/pcu/release.toml
@@ -1,4 +1,4 @@
-pre-release-commit-message = "chore: Release pcu v{{version}}"
+pre-release-commit-message = "chore: Release pcu v{{version}} [skip ci]"
 tag-message = "{{tag_name}}"
 tag-name = "pcu-v{{version}}"
 pre-release-hook = ["./release-hook.sh"]


### PR DESCRIPTION
## Why

Each crate's cargo-release commit is just a one-line `Cargo.toml` version bump on **already-validated** code — yet it currently triggers a full **~18-minute validation**, and that cost multiplies per crate in this multi-crate workspace.

These crates publish to crates.io **from within the release workflow** — there is **no tag-triggered pipeline** — so the ci-avoidance marker on the cargo-release commit only suppresses that one redundant **branch** validation. It cannot affect publishing.

## Change

Append the ci-avoidance marker to `pre-release-commit-message` in each crate's `release.toml` (`pcu`, `gen-bsky`, `gen-linkedin`). The cargo-release version-bump commits no longer trigger validation; CI runs **once**, after the final prlog push, over the up-to-date released code.

This is the crate-release half of the multi-crate skipping strategy (the prlog half is the controllable `--skip-ci` from #998 — the final prlog stays validating).

## Notes

- The marker lives only in the `release.toml` *files* (CI scans commit messages, not file contents), so this PR's own validation runs normally.
- For the binary crate, `inject_pubkey`'s `--amend --no-edit` preserves the marker through the pubkey-injection amend.
- Scoped to this multi-crate workspace; single-crate repos keep their cargo-release commit validating (their prlog is the one that skips).
