### PR TITLE
fix: disable consolidate-commits for per-crate release titles

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,11 @@
 sign-tag = true
 sign-commit = true
-consolidate-commits = true
+# Crates are released individually (cargo release --package <X> per crate), so we
+# get one commit per crate regardless — consolidate-commits would only matter for
+# a single whole-workspace `cargo release`. With it false, cargo-release uses each
+# crate's own pre-release-commit-message (informative title + the ci-avoidance
+# marker), instead of the generic workspace-level default.
+consolidate-commits = false
 allow-branch = ["main"]
 # PRLOG.md is now managed independently via scripts/release-prlog.sh
 # Each crate has its own tag prefix and CHANGELOG generation


### PR DESCRIPTION
## The bug

The release commits on `main` were generic `chore: Release` — no crate, no version, and no ci-avoidance marker (so #999 looked ineffective). Root cause: **`consolidate-commits = true`**.

With that set, cargo-release resolves the commit message at the **workspace** level. The workspace `release.toml` has no `pre-release-commit-message`, so it falls back to cargo-release 0.25's default `"chore: Release"` — and each crate's own `pre-release-commit-message` (which *does* carry the crate name, version and marker) is discarded.

## Why `false` is correct, not a workaround

`consolidate-commits` only does anything when a single `cargo release` invocation bumps multiple workspace members into **one** commit. The toolkit releases each crate **individually** (`cargo release --package <X>` per job, each with its own version), so we get one commit per crate either way — consolidation was never reducing the commit count here, only forcing the generic message and throwing away the informative per-crate ones.

## Fix

One line: `consolidate-commits = false`. The per-crate `pre-release-commit-message`s (already on `main` from #999) now take effect, so each release commit reads e.g. `chore: Release gen-bsky v0.1.31 [skip ci]` — informative **and** marked. Each version-bump commit skips its redundant validation; CI runs once after the final prlog.

## Verified

`cargo release --package gen-bsky <ver> --no-publish --no-push -vv` dry-run trace:
```
git commit -S -am chore: Release gen-bsky v0.1.31 [skip ci]
```
(vs the generic `chore: Release` with consolidate on). Per-crate `release.toml`s unchanged — they were correct all along; this just lets them apply.
