### PR TITLE
feat: default `pcu release` prlog commit to ci-skip

### DIFF
--- a/crates/pcu/src/cli.rs
+++ b/crates/pcu/src/cli.rs
@@ -322,16 +322,22 @@ mod tests {
     }
 
     #[test]
-    fn release_skip_ci_flag_is_negatable() {
+    fn release_skip_ci_defaults_to_skip_and_is_negatable() {
+        // Unlike `pcu pr` (which defaults to validate and is skipped only when
+        // the toolkit forces --skip-ci), the `release` command OWNS the default:
+        // the release work itself already validated, so the one-line
+        // post-release prlog commit skips by default. This lets the skip take
+        // effect even when the orb passes no flag (e.g. the toolkit's own
+        // release pulling unreleased pcu from main via update_pcu).
         let skip = |args: &[&str]| -> bool {
             match Cli::try_parse_from(args).unwrap().command {
-                Commands::Release(r) => r.skip_ci,
+                Commands::Release(r) => r.should_skip_ci(),
                 other => panic!("expected Release, got {other:?}"),
             }
         };
         assert!(
-            !skip(&["pcu", "release", "version", "1.0.0"]),
-            "default: validate (do not skip)"
+            skip(&["pcu", "release", "version", "1.0.0"]),
+            "default: skip (release work already validated)"
         );
         assert!(
             skip(&["pcu", "release", "--skip-ci", "version", "1.0.0"]),
@@ -339,7 +345,7 @@ mod tests {
         );
         assert!(
             !skip(&["pcu", "release", "--no-skip-ci", "version", "1.0.0"]),
-            "--no-skip-ci validates explicitly"
+            "--no-skip-ci opts back into validation"
         );
         assert!(
             !skip(&[

--- a/crates/pcu/src/cli/release.rs
+++ b/crates/pcu/src/cli/release.rs
@@ -211,14 +211,17 @@ pub struct Release {
     #[arg(long, default_value_t = false)]
     pub linkedin_share: bool,
     /// Skip CI on the prlog update commit by appending the ci-avoidance marker
-    /// (only takes effect on the default branch). Use it to drop the redundant
-    /// validation of a release-flow commit — the post-release prlog update in a
-    /// single-crate repo, or each crate release in a multi-crate repo.
+    /// (only takes effect on the default branch). This is the DEFAULT for
+    /// `release`: the release work itself was validated, so the one-line
+    /// post-release prlog commit need not be revalidated. `--skip-ci` states it
+    /// explicitly; pass `--no-skip-ci` to opt back into validation. The effective
+    /// decision is computed by [`Release::should_skip_ci`].
     #[arg(long, overrides_with = "no_skip_ci", default_value_t = false)]
     pub skip_ci: bool,
-    /// Explicitly do NOT skip CI on the prlog update commit (the default).
-    /// Provided so "skip the skip" is stated explicitly — e.g. the validating
-    /// final prlog of a multi-crate release. If both are given, the last wins.
+    /// Opt back into CI validation on the prlog update commit (release skips by
+    /// default). Needed by orb repos whose `v*` tag triggers the publish (the
+    /// marker must not reach the tagged commit) and by the validating final
+    /// prlog of a multi-crate release. If both flags are given, the last wins.
     #[arg(long = "no-skip-ci", action = clap::ArgAction::SetTrue, overrides_with = "skip_ci")]
     pub no_skip_ci: bool,
     #[command(subcommand)]
@@ -226,6 +229,17 @@ pub struct Release {
 }
 
 impl Release {
+    /// Effective ci-skip decision for the prlog update commit.
+    ///
+    /// `release` skips by default; `--no-skip-ci` opts back into validation.
+    /// The `overrides_with` relationship between the two flags makes the last
+    /// one on the command line win, so this need only consult `no_skip_ci`:
+    /// when `--skip-ci` is given last it resets `no_skip_ci` to false (skip),
+    /// and when `--no-skip-ci` is given last it sets it true (validate).
+    pub fn should_skip_ci(&self) -> bool {
+        !self.no_skip_ci
+    }
+
     pub async fn run_release(self, sign_config: SignConfig) -> Result<CIExit, Error> {
         let client = Commands::Release(self.clone()).get_client().await?;
 
@@ -361,7 +375,7 @@ impl Release {
             let on_default_branch = client.branch_or_main() == client.default_branch.as_str();
             let commit_message = super::with_skip_ci(
                 &release_prlog_commit_message(&version),
-                self.skip_ci,
+                self.should_skip_ci(),
                 on_default_branch,
             );
 


### PR DESCRIPTION
## What

`pcu release` now **skips CI on its prlog update commit by default**. The
negation flags are unchanged in mechanism — `--no-skip-ci` opts back into
validation, `--skip-ci` is the (now redundant) explicit form, last-wins via
`overrides_with` — but the *default* flips from validate to skip.

## Why a different default from `pcu pr`

`pcu pr` defaults to validate and is skipped only when the toolkit forces
`--skip-ci`. The release path runs a **different command** (`pcu release
--update-prlog`), and the toolkit's own release runs on an older dogfood orb
that passes no skip flag. For the post-release prlog skip to take effect there
— and specifically so the toolkit's own release (which pulls **unreleased pcu
from main** via `update_pcu`) produces a marker-bearing prlog commit — the
default has to live in the `release` command itself. That marker on the
workspace `v*` commit is what lets us observe whether the tag push still
triggers the orb-publish pipeline.

The release work itself was already validated, so re-validating the one-line
PRLOG edit is redundant; skipping it by default matches the post-merge
`update_prlog` convention.

## How

- New `Release::should_skip_ci()` returns `!no_skip_ci` (skip unless explicitly
  opted out); consumed at the `--update-prlog` commit instead of the raw field.
- Flag doc comments updated to state skip-by-default.
- `--no-skip-ci` is required by orb repos whose `v*` tag triggers the publish
  (the marker must not reach the tagged commit) and by multi-crate flows that
  validate once at the prlog.

RED/GREEN: the negation test now asserts default-skip via `should_skip_ci()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
