### PR TITLE
fix: lift RUSTSEC-2026-0173 (getset 0.1.7)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,18 +18,6 @@ ignore = [
     # decryption oracle) cannot be triggered. Remove when sigstore updates rsa.
     "RUSTSEC-2023-0071",
 
-    # RUSTSEC-2026-0173: proc-macro-error2 2.0.1 — unmaintained (2026-06-07).
-    # The proc-macro-error2 repo is ARCHIVED, so it will never be patched.
-    # Fix attempted: no fixed upstream exists. Remaining transitive path:
-    #   sigstore → oci-client → oci-spec → getset → proc-macro-error2
-    #     (getset is the blocker: inactive since 2025-06; jbaublitz/getset#132)
-    # (The gen-bsky → aquamarine path was removed: aquamarine replaced with the
-    #  zero-dependency simple-mermaid for rustdoc diagrams.)
-    # Unmaintained != vulnerable; no known CVE. Upstream tracking:
-    # jbaublitz/getset#132, youki-dev/oci-spec-rs#340 (filed by us).
-    # TEMPORARY — reviewed weekly; remove when a fixed getset/oci-spec ships.
-    "RUSTSEC-2026-0173",
-
 ]
 
 # Yanked-package checking re-enabled: core2 0.4.0 was removed from the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -834,7 +834,7 @@ workflows:
             branches:
               only:
                 - /pull\/[0-9]+/
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2026-0173"
+          ignore_advisories: "RUSTSEC-2023-0071"
       - toolkit/security:
           name: security with sonarcloud
           context: SonarCloud
@@ -842,6 +842,6 @@ workflows:
             branches:
               ignore:
                 - /pull\/[0-9]+/
-          ignore_advisories: "RUSTSEC-2023-0071 RUSTSEC-2026-0173"
+          ignore_advisories: "RUSTSEC-2023-0071"
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1802,11 +1802,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3726,28 +3725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bump `getset` 0.1.6 → **0.1.7** and remove the `RUSTSEC-2026-0173` ignore.

`getset 0.1.7` dropped `proc-macro-error2` (the archived/unmaintained crate
behind the advisory). It was the **sole remaining path** to it in this tree:

- the `gen-bsky → aquamarine` path was removed earlier (replaced with
  `simple-mermaid`), and
- `oci-spec` requires `getset ^0.1.3`, which permits 0.1.7 — so a plain
  `cargo update -p getset --precise 0.1.7` clears it, **no oci-spec change
  needed** (our tracking issue youki-dev/oci-spec-rs#340 is no longer blocking).

`proc-macro-error2` and `proc-macro-error-attr2` are gone from `Cargo.lock`.

## Ignore removed from both sinks (kept in sync)

- `.cargo/audit.toml` — the `RUSTSEC-2026-0173` block
- `.circleci/config.yml` — `ignore_advisories` on both `toolkit/security` jobs

`RUSTSEC-2023-0071` (rsa / sigstore Marvin-attack) stays ignored — unrelated and
still upstream-blocked.

## Verification

- Naked audit (no config, from `/tmp`): only `RUSTSEC-2023-0071` remains — no
  `proc-macro-error2`.
- Configured audit: exit 0.
- `cargo fmt --all --check`, `clippy --all-targets --all-features -D warnings`,
  213 tests, `cargo msrv verify` @ 1.89.0 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
