### PR TITLE
fix(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
Bump `anyhow` 1.0.102 → 1.0.103 to clear **RUSTSEC-2026-0190** (Error::downcast_mut() unsoundness, published 2026-06-25), which fails `cargo audit -D warnings`.

Verified: fmt, clippy --all-targets --all-features -D warnings, 213 tests, audit clean, msrv 1.89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)