### PR TITLE
fix(deps): update event-listener to 5.4.2 for RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,15 +751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "config"
 version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,11 +1463,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Clears **RUSTSEC-2026-0221**, which is failing CI on every branch and on `main`.

`event-listener` 5.4.1 unconditionally implements `Send`/`Sync` for `StackSlot`, so a `!Send` tag set via `Event::with_tag` can cross a thread boundary and race in safe code. Advisory published 2026-07-13; 5.4.2 carries the fix (`patched = [">= 5.4.2"]`).

## Why it appeared now, and why local checks missed it

The advisory is **informational (`unsound`)** rather than a vulnerability. `cargo deny check advisories` — which is what `just audit` runs — passes it, so a local `just audit` is green. CI runs `cargo audit -D warnings`, which promotes it to a failure. Worth knowing that the two tools disagree here by design: a clean `just audit` does not imply a clean CI security job.

## Why Renovate did not raise it

The dependency is deep and entirely transitive:

```
pcu -> bsky-sdk -> atrium-api -> atrium-common -> moka -> async-lock -> event-listener
```

No manifest anywhere in the workspace names it, so there is nothing for Renovate to bump — transitive advisories are resolved by a lockfile update, not a version bump. `cargo update -p event-listener --precise 5.4.2` is semver-compatible and changes no dependency tree; `concurrent-queue` 2.5.0 simply drops out (578 → 577 crates).

## Verification

- `cargo audit -D warnings --ignore RUSTSEC-2023-0071` — the exact CI command — now passes
- `just audit` still clean on all four checks
- 239 tests pass; clippy (`--all --tests --all-features -- -D warnings`), `fmt --check`, `just git-only` and `cargo msrv verify` (1.89.0, mandatory as `Cargo.lock` changed) all clean
- Stale-ignore probe run from outside the workspace so no config is picked up: the only advisory still reported is RUSTSEC-2023-0071, which remains legitimately suppressed and is **not** stale

## Standalone by design

Kept separate from #1033 (the `stage_paths` fix) so it can merge immediately — it unblocks every open PR, not just that one. #1033 will pick it up on merge from `main`.
